### PR TITLE
release: v0.3.0 — essence-alpha-mcp authoritative backend

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/.claude/sdlc/alphas.md
+++ b/.claude/sdlc/alphas.md
@@ -2,7 +2,7 @@
 name: alphas
 type: alpha-snapshot
 project: ai-driven-sdlc-plugin
-updated: 2026-05-01
+updated: 2026-05-02
 source_of_truth: mcp://essence-alpha
 snapshot_role: pr-visible-mirror
 generated_after: mcp-write
@@ -22,7 +22,7 @@ generated_after: mcp-write
 | Opportunity | Value Established | `.claude/sdlc/phases/vision/vision.md` | 2026-04-19 |
 | Stakeholders | Involved | `.claude/sdlc/phases/requirements/requirements.md` | 2026-04-19 |
 | Requirements | Acceptable | `.claude/sdlc/phases/architecture/architecture.md` | 2026-04-19 |
-| Software System | Usable | `CHANGELOG.md#0.2.1` | 2026-04-21 |
+| Software System | Usable | `CHANGELOG.md#0.3.0` | 2026-05-02 |
 | Work | Under Control | `tests/unit/validate-artifact.bats` | 2026-04-19 |
 | Team | Seeded | `.claude/sdlc/roles.md` | 2026-04-19 |
 | Way of Working | Working Well | `.claude/sdlc/phases/testing/testing.md` §7a | 2026-05-01 |
@@ -46,3 +46,6 @@ Snapshot и БД синхронизированы по итогам Стадии
 - 2026-05-01: way-of-working In Use → In Place; затем In Place → Working Well.
 - Evidence обоих переходов — `phases/testing/testing.md` §7a.
 - Триггер — расширение bench-hooks с 5 до 8 hooks.
+- 2026-05-02: software-system Usable → Demonstrable → Usable (refresh evidence).
+- Evidence обновлён на `CHANGELOG.md` секция [0.3.0]; rationale — релиз v0.3.0.
+- Состояние Usable сохранено; продвижение на Ready отложено до Стадии D.

--- a/.claude/sdlc/audit.md
+++ b/.claude/sdlc/audit.md
@@ -2,71 +2,84 @@
 name: audit
 type: audit-report
 project: ai-driven-sdlc-plugin
-run_at: 2026-05-01 09:00
-applied_at: 2026-05-01 09:10
+run_at: 2026-05-02 12:00
+applied_at: 2026-05-02 12:10
 auditor: sdlc-consistency-auditor
 status: pass
-issues_count: 3
-issues_resolved: 2
-issues_closed_as_fp: 1
+issues_count: 5
+issues_resolved: 4
+issues_closed_as_history: 1
 ---
 
 # Отчёт сквозного аудита SDLC-артефактов
 
 ## 1. Резюме
 
-Прогон в рамках Стадии B плана `essence-alpha-mcp-serene-ember`.
-Расширен `bench-hooks.sh` 5→8 hooks (NFR `hooks-performance`).
-Добавлена memom-запись о принципе 13 (закрывает находку #2 предыдущего аудита).
-Первое реальное продвижение Way of Working через MCP: In Use → In Place → Working Well.
+Прогон в рамках Стадии C плана `essence-alpha-mcp-serene-ember`.
+Bump 0.2.1 → 0.3.0; CHANGELOG секция [0.3.0]; release-notes файл; deployment.md §5a release log.
 
-Все детерминированные проверки чистые: 31/31 bats, 0 violations validate, cross-refs OK, readme-inventory OK, memom-consistency OK, bench-hooks 8/8 <200ms.
+Все детерминированные проверки чистые: 31/31 bats, 0 violations validate, cross-refs OK, readme-inventory OK, memom-consistency OK, alpha-consistency OK.
 
-Найдено 3 расхождения уровня note: 2 применены, 1 закрыта как false positive.
-Финальный статус — **pass**.
+Найдено 5 расхождений (2 important, 3 note); 4 применены, 1 закрыта как историческая запись CHANGELOG. Финальный статус — **pass**.
 
 ## 2. Проверки
 
 | Проверка | Статус | Детали |
 |---|---|---|
-| Трассируемость фаз | pass | testing.md §7a сохраняет traces_from на architecture.md §4 |
-| Соответствие уровню SME | pass | testing=mid; пирамида + fitness + coverage-gate |
-| Альфы ↔ артефакты (через MCP) | pass | Way of Working = Working Well; журнал MCP-продвижений зафиксирован |
-| System-context ↔ архитектура | pass | журнал фокусировок дополнен записью Стадии B |
+| Согласованность версий v0.3.0 | pass | plugin.json, README, CHANGELOG, release-notes, deployment.md §5a |
+| CHANGELOG покрытие Стадий A+B | pass | Added=8, Changed=9, Fixed=2 |
+| Трассируемость фаз | pass | deployment.md traces_from/to корректны |
+| Соответствие SME | pass | deployment=mid; §1-6 + §5a release log |
+| Альфы ↔ артефакты (через MCP) | pass | Software System evidence обновлён на CHANGELOG#0.3.0 через MCP |
+| System-context ↔ артефакты | pass | current_focus=essence-alpha-mcp согласован |
 | Осиротевшие ссылки | pass | check-cross-refs OK |
 | Правило ≤15 слов | pass | validate-artifact 0 violations |
-| TDD-семантика | pass | 31/31 bats; пары source↔test зафиксированы |
-| README инвентарь (принцип 16) | pass | bench-hooks описание 5→8 hooks |
+| TDD-семантика | pass | изменения только в md/json |
 | Memom-консистентность | pass | принцип 13 + memom синхронны |
+| Принцип 16 (README inventory) | pass | scripts=13, bats=6 файлов/31 кейс |
+| Принцип 13 (Software System отложен) | pass | Software System остаётся Usable; advance к Ready отложен до Стадии D |
 
 ## 3. Найденные расхождения
 
-### Note-01 — даты `2026-05-01` в decisions.md и memom.md
+### Находка #1 — evidence Software System устарел
 
-- **Критичность:** note (false positive).
-- **Локация:** memom.md, decisions.md секции Стадии B.
-- **Описание:** Аудитор посчитал даты «будущим». Реальный currentDate среды — 2026-05-01.
-- **Резолюция:** false positive; даты корректны.
+- **Критичность:** important
+- **Локация:** `.claude/sdlc/alphas.md` строка 25
+- **Описание:** evidence указывал на CHANGELOG#0.2.1 (2026-04-21); ожидался refresh для релиза v0.3.0.
 
-### Note-02 — system-context.md не отражает работу со Стадии B
+### Находка #2 — release-notes-v0.3.0.md контракт
 
-- **Критичность:** note.
-- **Локация:** `.claude/sdlc/system-context.md` журнал фокусировок.
-- **Описание:** Стадия B затронула подсистему hooks (расширение bench), но запись в журнале отсутствовала.
+- **Критичность:** important
+- **Локация:** корень репо, `.gitignore`
+- **Описание:** временный файл для `gh release create --notes-file` без зафиксированного контракта.
 
-### Note-03 — `related_commits` содержит PR-номера, не SHA
+### Находка #3 — CHANGELOG ≤15 слов в исторической записи
 
-- **Критичность:** note.
-- **Локация:** `memom.md` запись 2026-05-01 строка `related_commits`.
-- **Описание:** Формат записи требовал хеши; PR-ссылки были pre-merge state.
+- **Критичность:** note (closed as history)
+- **Локация:** `CHANGELOG.md` секция [0.2.0]
+- **Описание:** строка из старой версии превышает порог; историческая запись неприкосновенна.
+
+### Находка #4 — ссылка на ADR в release-notes без markdown-обёртки
+
+- **Критичность:** note
+- **Локация:** `release-notes-v0.3.0.md` строка 83
+- **Описание:** inline-путь без markdown-обёртки не рендерится как кликабельная ссылка.
+
+### Находка #5 — опечатка Pakage в release-notes
+
+- **Критичность:** note
+- **Локация:** `release-notes-v0.3.0.md` строка 85
+- **Описание:** Pakage → Package.
 
 ## 4. Применённые фиксы
 
 | # | Уровень | Действие | Артефакт |
 |---|---|---|---|
-| Note-01 | note (FP) | Закрыто как false positive — currentDate совпадает с датой записи | — |
-| Note-02 | note | Журнал фокусировок дополнен записью 2026-05-01 без смены current_focus | `.claude/sdlc/system-context.md` |
-| Note-03 | note | Формат записи memom.md формализован: разрешены PR-ссылки до merge | `memom.md` |
+| #1 | important | regress + advance через MCP; evidence → CHANGELOG#0.3.0 | `alphas.md`, БД essence-alpha |
+| #2 | important | `.gitignore` паттерн `release-notes-v*.md` | `.gitignore` |
+| #3 | note | Закрыто как историческая запись CHANGELOG (не SDLC-артефакт) | — |
+| #4 | note | inline-путь обёрнут в markdown-ссылку | `release-notes-v0.3.0.md` |
+| #5 | note | Pakage → Package | `release-notes-v0.3.0.md` |
 
 ## 5. Привязка к альфам
 
@@ -77,13 +90,13 @@ issues_closed_as_fp: 1
 | Opportunity | Value Established | `phases/vision/vision.md` |
 | Stakeholders | Involved | `phases/requirements/requirements.md` |
 | Requirements | Acceptable | `phases/architecture/architecture.md` |
-| Software System | Usable | `CHANGELOG.md` |
+| Software System | Usable | `CHANGELOG.md#0.3.0` (refreshed) |
 | Work | Under Control | `tests/unit/validate-artifact.bats` |
 | Team | Seeded | `roles.md` |
-| Way of Working | **Working Well** | `phases/testing/testing.md` §7a |
+| Way of Working | Working Well | `phases/testing/testing.md` §7a |
 
-`essence_validate_consistency` ok=true; БД содержит 23 перехода (21 seed + 2 Стадия B).
+`essence_validate_consistency` ok=true; БД содержит 25 переходов (21 seed + 2 Стадия B + 2 Стадия C).
 
 ## 6. Финальный статус
 
-**pass** — 2 note применены, 1 закрыта как FP. Stage B готова к PR-B.
+**pass** — 4 фикса применены, 1 закрыта как история. Stage C готова к PR-C и release v0.3.0.

--- a/.claude/sdlc/decisions.md
+++ b/.claude/sdlc/decisions.md
@@ -10,6 +10,59 @@ updated: 2026-04-30
 
 Принцип 1: альтернативы порождаются и фиксируются; выбор делает пользователь.
 
+## 2026-05-02 — релиз v0.3.0 (Стадия C)
+
+- context: завершение цикла essence-alpha-mcp; bump 0.2.1 → 0.3.0.
+- autonomy_mode: hootl
+- phase: deployment
+- role: method-engineer
+- alternatives:
+  1. Minor 0.3.0 (выбрано) — новый MCP-сервер + ADR + script = feature.
+  2. Patch 0.2.2 — рискованно, нарушает SemVer.
+  3. RC 0.3.0-rc.1 — лишний цикл для dogfooding.
+- choice: 1
+- rationale: новый authoritative backend трекера — major feature.
+- impl: plugin.json 0.3.0; CHANGELOG секция [0.3.0]; release-notes файл.
+- impl: deployment.md §5a release log; ветка release/v0.3.0.
+- traces_to:
+  - `.claude-plugin/plugin.json`
+  - `CHANGELOG.md` секция [0.3.0]
+  - `release-notes-v0.3.0.md`
+  - `.claude/sdlc/phases/deployment/deployment.md` §5a
+
+## 2026-05-02 — фиксы аудита Стадии C
+
+- context: 5 находок (2 important, 3 note); все применены.
+- autonomy_mode: hootl
+- phase: deployment
+- role: method-engineer
+
+### Находка #1 — evidence Software System устарел
+
+- alternatives:
+  1. Refresh через MCP (regress + advance) с CHANGELOG#0.3.0 (выбрано).
+  2. Manual edit snapshot без MCP-журнала.
+  3. Отложить до Стадии D.
+- choice: 1
+- rationale: атомарность через MCP сохраняет журнал переходов.
+- impl: regress Usable→Demonstrable; advance Demonstrable→Usable с новым URI.
+
+### Находка #2 — release-notes-v0.3.0.md контракт
+
+- alternatives:
+  1. .gitignore release-notes-v*.md; передавать через --notes-file (выбрано).
+  2. Коммитить в docs/releases/ как permanent артефакт.
+  3. Inline тело через CHANGELOG-фрагмент.
+- choice: 1
+- rationale: временный артефакт; gh передаёт через файл.
+- impl: `.gitignore` дополнен паттерном `release-notes-v*.md`.
+
+### Находки #3, #4, #5 — note
+
+- #3 CHANGELOG ≤15 слов — историческая запись неприкосновенна.
+- #4 ссылка на ADR — переписана как relative markdown link.
+- #5 опечатка Pakage→Package — исправлена.
+
 ## 2026-05-01 — расширение bench-hooks 5→8 (Стадия B)
 
 - context: NFR hooks-performance не покрывал 3 hooks.

--- a/.claude/sdlc/phases/deployment/deployment.md
+++ b/.claude/sdlc/phases/deployment/deployment.md
@@ -15,7 +15,7 @@ traces_to:
   - ../operations/operations.md
 system_of_attention: ai-driven-sdlc-plugin
 created: 2026-04-19
-updated: 2026-04-19
+updated: 2026-05-01
 ---
 
 # Стратегия фазы deployment плагина ai-driven-sdlc
@@ -95,6 +95,17 @@ updated: 2026-04-19
 - Release gate зафиксирован (§3.5).
 - Готов к первому релизу через процесс §3.2.
 - Альфа Software System может достичь Usable после первого успешного релиза.
+
+## 5a. Release log
+
+### 2026-05-01 — релиз v0.3.0
+
+- highlight: интеграция `@ypolosov/essence-alpha-mcp` как authoritative backend.
+- bump: minor (новый MCP-сервер + ADR-009 + script + 2 NFR).
+- artifacts: `release-notes-v0.3.0.md`, CHANGELOG секция [0.3.0], git tag.
+- alphas: Way of Working продвинута через MCP до Working Well.
+- breaking: нет; обратная совместимость snapshot-формата сохранена.
+- bootstrap для existing проектов: `bash scripts/seed-essence-alpha.sh`.
 
 ## 6. Открытые вопросы
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 .claude/sdlc/essence-alpha.db-journal
 .claude/sdlc/essence-alpha.db-wal
 .claude/sdlc/essence-alpha.db-shm
+
+# ai-driven-sdlc: временные release notes для gh release create --notes-file
+release-notes-v*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-05-01
+
+### Added
+- Интеграция MCP-сервера `@ypolosov/essence-alpha-mcp` как authoritative backend трекера альф (ADR-009).
+- `scripts/check-alpha-consistency.sh` — PostToolUse hook валидации БД essence-alpha.
+- `scripts/seed-essence-alpha.sh` — bootstrap БД с цепочками переходов OMG Essence.
+- `tests/unit/check-alpha-consistency.bats` (5 кейсов), `tests/unit/seed-essence-alpha.bats` (4 кейса).
+- ADR-009 essence-alpha-mcp integration; NFR `reliability` и `maintainability`.
+- `external-systems/essence-alpha-mcp.md` — sidecar logical-системы (Принцип 17).
+- `meta-templates/alpha-state.meta.md`: режим `alpha-snapshot` плюс поля `source_of_truth`, `snapshot_role`, `generated_after`.
+- `phases/testing/testing.md` §7a — снимок latency 8 hooks.
+
+### Changed
+- `alphas.md` сжат до PR-видимого snapshot; журнал переходов делегирован MCP-БД.
+- `agents/sdlc-alpha-tracker.md`: 6 MCP-tools; маппинг PascalCase ↔ kebab-case.
+- `scripts/bench-hooks.sh` расширен с 5 до 8 hooks (+ check-alpha-consistency, enforce-no-comments, enforce-format-lint).
+- `phases/architecture/architecture.md`: ADR-009 в §5; NFR reliability/maintainability в §4.
+- `CLAUDE.md` принцип 13: дополнено упоминанием MCP-backend и snapshot-роли markdown.
+- `memom.md`: запись `2026-05-01 — Принцип 13: детерминированный backend через essence-alpha-mcp`.
+- `plugin-config.md`: 6 активных tdd_pairs (было 4 в 0.2.1).
+- README: scripts 11→13, bats 4→6 файлов, 21→31 кейс, MCP инвентарь.
+- Альфа Way of Working продвинута через MCP до **Working Well** (была In Use).
+
+### Fixed
+- `validate-artifact.sh` парсер ≤15 слов: false positive на нумерованных заголовках.
+- 7 находок аудита 2026-04-30 (issue templates, focus_count, evidence-version).
+
 ## [0.2.1] — 2026-04-19
 
 ### Fixed
@@ -59,7 +86,8 @@
 - Принципы Волны 1 (1-13 + 4a).
 - Демо-сценарий на todo-list.
 
-[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 ## Статус
 
-Текущая версия: **v0.2.1** (апрель 2026).
+Текущая версия: **v0.3.0** (май 2026).
 Волна 1 и Волна 2 закрыты; Волна 3 в работе — см. [milestones](https://github.com/ypolosov/ai-driven-sdlc-plugin/milestones).
 Альфа Software System: **Usable** — плагин устанавливается через marketplace.
+Альфа Way of Working: **Working Well** — fitness 8 hooks <200ms; самоприменение SDLC.
 Конституция плагина: 17 принципов + 4a, см. [CLAUDE.md](CLAUDE.md).
 
 ## Опорные источники


### PR DESCRIPTION
## Summary

- `plugin.json` 0.2.1 → 0.3.0 (SemVer minor).
- `CHANGELOG.md` секция [0.3.0] закрывает Стадии A и B.
- `deployment.md` §5a release log.
- Software System evidence обновлён через MCP regress+advance на CHANGELOG#0.3.0.
- `.gitignore` дополнен паттерном `release-notes-v*.md`.

## Test plan

- [x] 31/31 bats зелёные
- [x] validate-artifact 0 violations
- [x] check-cross-refs OK
- [x] check-readme-inventory OK
- [x] check-memom-consistency OK
- [x] check-alpha-consistency OK
- [x] bench-hooks 8/8 <200ms
- [x] essence_validate_consistency ok=true (25 переходов)
- [x] /sdlc-audit статус pass

## Release flow (после merge)

1. `git checkout main && git pull`
2. `git tag v0.3.0`
3. `git push origin v0.3.0`
4. `gh release create v0.3.0 --notes-file release-notes-v0.3.0.md`
5. Verify через `/plugin install ai-driven-sdlc@0.3.0` в новой Claude Code сессии

🤖 Generated with [Claude Code](https://claude.com/claude-code)