### PR TITLE
chore(operations): soak setup для v0.3.0

### DIFF
--- a/.claude/sdlc/decisions.md
+++ b/.claude/sdlc/decisions.md
@@ -10,6 +10,25 @@ updated: 2026-04-30
 
 Принцип 1: альтернативы порождаются и фиксируются; выбор делает пользователь.
 
+## 2026-05-02 — soak setup для v0.3.0 (Стадия D)
+
+- context: release v0.3.0 опубликован; стартует soak 7 дней.
+- autonomy_mode: hootl
+- phase: operations
+- role: method-engineer
+- alternatives:
+  1. Soak 7 дней + label essence-alpha-feedback (выбрано).
+  2. Soak 30 дней — слишком долго для pet-уровня SME.
+  3. Без soak; продвинуть альфы сразу — нечестно без эксплуатации.
+- choice: 1
+- rationale: 7 дней — баланс между fairness и темпом.
+- impl: GitHub label `essence-alpha-feedback` создан.
+- impl: operations.md §5a soak план; метрики и условия advance.
+- impl: финальный аудит `/sdlc-audit` отложен до 2026-05-09.
+- traces_to:
+  - GitHub label essence-alpha-feedback
+  - `.claude/sdlc/phases/operations/operations.md` §5a
+
 ## 2026-05-02 — релиз v0.3.0 (Стадия C)
 
 - context: завершение цикла essence-alpha-mcp; bump 0.2.1 → 0.3.0.

--- a/.claude/sdlc/phases/operations/operations.md
+++ b/.claude/sdlc/phases/operations/operations.md
@@ -14,7 +14,7 @@ traces_from:
 traces_to: []
 system_of_attention: ai-driven-sdlc-plugin
 created: 2026-04-19
-updated: 2026-04-30
+updated: 2026-05-02
 ---
 
 # Стратегия фазы operations плагина ai-driven-sdlc
@@ -95,6 +95,23 @@ Milestones: `Wave 1` (closed), `Wave 2` (closed), `Wave 3` (текущий backl
 - `SUPPORT.md` в корне репозитория.
 - `CHANGELOG.md` процесс (из deployment.md) согласован с issue triage.
 - Альфа Opportunity может достичь Addressed при первом внешнем пользователе.
+
+## 5a. Soak-периоды релизов
+
+### Soak v0.3.0 (2026-05-02 → 2026-05-09)
+
+- Релиз: v0.3.0 essence-alpha-mcp authoritative backend.
+- Канал feedback: GitHub Issues label `essence-alpha-feedback`.
+- Метрики soak (manual weekly):
+  - Внешние установки v0.3.0 через GitHub Insights.
+  - Issue с label `essence-alpha-feedback`.
+  - `essence_validate_consistency` ok-стабильность.
+  - `bench-hooks.sh` latency 8 hooks <200ms.
+- Цель soak — ≥1 external feedback подтверждающего value.
+- При успехе: продвинуть Software System Usable → Ready через MCP.
+- При успехе: продвинуть Opportunity Value Established → Addressed через MCP.
+- При critical issue: patch v0.3.1 через `/sdlc-phase deployment`.
+- Финальный аудит: `/sdlc-audit` после soak; запись итогов в decisions.md.
 
 ## 6. Открытые вопросы
 


### PR DESCRIPTION
Setup soak-периода 2026-05-02 → 2026-05-09. Создан GitHub label essence-alpha-feedback. План метрик в operations.md §5a.