### PR TITLE
fix(mcp): direct essence-alpha-mcp binary instead of npx -y

### DIFF
--- a/.claude/sdlc/external-systems/essence-alpha-mcp.md
+++ b/.claude/sdlc/external-systems/essence-alpha-mcp.md
@@ -13,10 +13,12 @@ updated: 2026-04-30
 
 ## 1. Назначение и границы
 
-Внешний npm-пакет `@ypolosov/essence-alpha-mcp` v0.1.0+.
+Внешний npm-пакет `@ypolosov/essence-alpha-mcp` v0.1.1+.
 Предоставляет детерминированную state machine 7 альф OMG Essence 1.2.
-Запускается через `npx -y` как stdio MCP-сервер либо CLI.
+Устанавливается глобально (`npm install -g`) и запускается как `essence-alpha-mcp serve` (stdio MCP) либо CLI.
 Граница — npm-пакет; код в репо `github.com/ypolosov/essence-alpha-mcp`.
+
+В v0.1.0 был баг ранний-exit stdio-сервера (исправлен в v0.1.1) — минимальная поддерживаемая версия v0.1.1.
 
 ## 2. Текущий фокус
 

--- a/.claude/sdlc/phases/architecture/adr/ADR-009-essence-alpha-mcp-integration.md
+++ b/.claude/sdlc/phases/architecture/adr/ADR-009-essence-alpha-mcp-integration.md
@@ -16,7 +16,7 @@ principles: [6, 13]
 Markdown не даёт детерминированной валидации переходов state machine.
 OMG Essence — формальная state machine 7 альф SDLC.
 Класс багов: «agent забыл состояние», «evidence_uri ссылается в никуда», «журнал рассинхронизирован».
-Опубликован npm-пакет `@ypolosov/essence-alpha-mcp` v0.1.0.
+Опубликован npm-пакет `@ypolosov/essence-alpha-mcp` v0.1.1 (минимальная поддерживаемая; v0.1.0 имел баг ранний-exit stdio).
 
 ## Решение
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,10 +11,8 @@
     },
     "essence-alpha": {
       "type": "stdio",
-      "command": "npx",
+      "command": "essence-alpha-mcp",
       "args": [
-        "-y",
-        "@ypolosov/essence-alpha-mcp",
         "serve"
       ],
       "env": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- `.mcp.json` для `essence-alpha`: `npx -y @ypolosov/essence-alpha-mcp` заменён на прямой `essence-alpha-mcp serve`. NPX cold-fetch (127 deps) превышал таймаут health-check Claude Code, плагиновая запись отображалась как Failed to connect даже на исправной версии CLI.
+- Скрипты `seed-essence-alpha.sh` и `check-alpha-consistency.sh`: дефолт `ESSENCE_ALPHA_CMD` / `ESSENCE_ALPHA_VALIDATE_CMD` переключён с `npx -y` на прямой бинарник.
+
+### Changed
+- README §MCP-серверы: требование `npm install -g @ypolosov/essence-alpha-mcp` (минимум v0.1.1) перед использованием плагина.
+- ADR-009 / external-systems/essence-alpha-mcp.md: минимум v0.1.1 (исправлен ранний-exit stdio сервера в v0.1.0).
+
 ## [0.3.0] — 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@
 
 - `context7@claude-plugins-official` — референсная документация инструментов (обязательно для SME-опроса).
 - `github@claude-plugins-official` — GitHub Issues как state_artifact для альфы Work (опционально, mid+).
-- `@ypolosov/essence-alpha-mcp` v0.1.0+ — детерминированный backend трекера альф (см. ADR-009).
+- `@ypolosov/essence-alpha-mcp` v0.1.1+ — детерминированный backend трекера альф (см. ADR-009).
 
 Плагин не ship'ит собственный `context7` — используйте dedicated плагин.
 Плагин ship'ит минимальный `github` MCP в `.mcp.json` как fallback.
-Плагин ship'ит запись `essence-alpha` в `.mcp.json`; пакет тянется через `npx`.
+Плагин ship'ит запись `essence-alpha` в `.mcp.json` и ожидает глобально установленный CLI:
+
+```bash
+npm install -g @ypolosov/essence-alpha-mcp
+```
+
+Прямой запуск через `essence-alpha-mcp serve` (вместо `npx -y`) даёт мгновенный старт сервера и стабильный health-check Claude Code (npx с пустым кэшем + cold install 127 deps превышает таймаут проверки).
 
 ## Быстрый старт
 

--- a/scripts/check-alpha-consistency.sh
+++ b/scripts/check-alpha-consistency.sh
@@ -16,7 +16,7 @@ case "$file_path" in
   *) exit 0 ;;
 esac
 
-cmd="${ESSENCE_ALPHA_VALIDATE_CMD:-npx -y @ypolosov/essence-alpha-mcp validate}"
+cmd="${ESSENCE_ALPHA_VALIDATE_CMD:-essence-alpha-mcp validate}"
 log_file="$(mktemp)"
 trap 'rm -f "$log_file"' EXIT
 

--- a/scripts/seed-essence-alpha.sh
+++ b/scripts/seed-essence-alpha.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cmd="${ESSENCE_ALPHA_CMD:-npx -y @ypolosov/essence-alpha-mcp}"
+cmd="${ESSENCE_ALPHA_CMD:-essence-alpha-mcp}"
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 dry_run=0
 


### PR DESCRIPTION
## Summary

Plugin's `essence-alpha` entry in `.mcp.json` used `npx -y @ypolosov/essence-alpha-mcp serve`. NPX cold-fetch (127 deps) exceeds Claude Code MCP health-check timeout, so `claude mcp list` shows `✗ Failed to connect` even when the package is healthy. Direct call to globally-installed `essence-alpha-mcp` starts in milliseconds.

Verified locally: `essence-alpha-mcp@0.1.1` installed via `npm install -g`, real stdio handshake returns 7 tools.

## Changes

- `.mcp.json`: `command: "essence-alpha-mcp", args: ["serve"]` (no npx).
- `scripts/seed-essence-alpha.sh`: `ESSENCE_ALPHA_CMD` default → direct binary.
- `scripts/check-alpha-consistency.sh`: `ESSENCE_ALPHA_VALIDATE_CMD` default → direct binary.
- `README.md`: install instruction `npm install -g @ypolosov/essence-alpha-mcp`.
- ADR-009 + `external-systems/essence-alpha-mcp.md`: minimum supported v0.1.1 (v0.1.0 had stdio early-exit bug).
- `CHANGELOG.md`: Unreleased / Fixed + Changed.

ENV overrides preserved — users without global install can still set `ESSENCE_ALPHA_CMD='npx -y @ypolosov/essence-alpha-mcp'`.

## Test plan

- [ ] `bats tests/unit/check-alpha-consistency.bats` — should pass (tests override ENV).
- [ ] `bats tests/unit/seed-essence-alpha.bats` — should pass (uses mock).
- [ ] In a target project: `npm install -g @ypolosov/essence-alpha-mcp` then `claude mcp list` shows essence-alpha as ✓ Connected.

## Related

- essence-alpha-mcp v0.1.1 fix: https://github.com/ypolosov/essence-alpha-mcp/releases/tag/v0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)