### PR TITLE
feat(migrate): scripts/migrate-essence-to-state-rag.sh + .gitignore .sdlc-db/ + bats (PR-H Wave 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # ai-driven-sdlc: временные release notes для gh release create --notes-file
 release-notes-v*.md
+
+# ai-driven-sdlc: pglite/sdlc-state-rag локальная БД (Wave 5, ADR-011)
+.sdlc-db/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 ## [Unreleased]
 
+### Added (Wave 5 — preparation for v0.4.0)
+- `scripts/migrate-essence-to-state-rag.sh` — разовая утилита миграции dogfooding-target с режимами `--dry-run`, `--verify`, `--exec`.
+- `tests/unit/migrate-essence-to-state-rag.bats` — 7 кейсов: exists, missing source, dry-run, exec+backup, idempotency, verify, help.
+- `.gitignore` запись `.sdlc-db/` для pglite/sdlc-state-rag локальной БД (ADR-011).
+
+### Pending (will land in v0.4.0)
+- Merge цепочки PR-A..G Wave 4/5 (PR #29..#35 → main).
+- Публикация `@ypolosov/sdlc-state-rag` v0.1.0 на npm.
+- Dogfooding-миграция плагина на новый backend.
+
+### BREAKING (v0.4.0)
+- `essence-alpha-mcp` удаляется из `.mcp.json`; `sdlc-alpha-tracker` дёргает только `sdlc-state-rag`.
+- ENV var `ESSENCE_ALPHA_VALIDATE_CMD` переименован в `SDLC_STATE_RAG_VALIDATE_CMD` (старая переменная даёт deprecation warning одну версию).
+
 ## [0.3.1] — 2026-05-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@
 - `sdlc-tool-router` — маршрутизация запросов по категориям к MCP-серверам (Волна 4).
 - `sdlc-context-aggregator` — фасад консолидации контекста с провенансом (Волна 4, ADR-010).
 
-### Scripts (16)
+### Scripts (17)
 - `validate-artifact.sh` — frontmatter, секции, ≤15 слов, русский.
 - `enforce-tdd.sh` — мягкая блокировка записи кода без парного теста.
 - `enforce-format-lint.sh` — диспетчер форматера и линтера из `plugin-config.md`.
@@ -108,6 +108,7 @@
 - `check-tool-binding.sh` — валидирует категории `tool-bindings.md` целевого (Волна 4).
 - `detect-credentials.sh` — проверяет `.env` и обязательные ключи привязок (Волна 4).
 - `check-rag-config.sh` — валидирует `rag-config.md` целевого и worker.kind ↔ SME (Волна 5, ADR-012).
+- `migrate-essence-to-state-rag.sh` — разовая миграция dogfooding с `--dry-run` / `--verify` / `--exec` (Волна 5, PR-H).
 
 ### Meta-templates (16)
 - `work-product.meta.md` — базовая схема рабочего продукта.

--- a/scripts/migrate-essence-to-state-rag.sh
+++ b/scripts/migrate-essence-to-state-rag.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="exec"
+source_path=""
+backup_path=""
+target_root="${SDLC_TARGET_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+usage() {
+  cat <<'EOF'
+migrate-essence-to-state-rag — разовая миграция dogfooding-target
+
+Использование:
+  migrate-essence-to-state-rag.sh [--dry-run|--verify|--exec] [--source <path>] [--backup <path>]
+
+Режимы:
+  --dry-run   Показать план без изменений (default).
+  --verify    Сравнить snapshot с состоянием sdlc-state-rag.
+  --exec      Выполнить миграцию (с обязательным backup).
+
+Параметры:
+  --source <path>  Snapshot alphas.md (default: <target>/.claude/sdlc/alphas.md).
+  --backup <path>  Куда сохранить backup (default: <source>.backup-<date>).
+
+ENV:
+  SDLC_STATE_RAG_DSN          Connection string для PostgreSQL (опционально).
+  SDLC_STATE_RAG_PGLITE_DIR   Путь pglite-БД (если без DSN).
+  SDLC_TARGET_ROOT            Корень целевого (default: git root).
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      mode="dry-run"
+      shift
+      ;;
+    --verify)
+      mode="verify"
+      shift
+      ;;
+    --exec)
+      mode="exec"
+      shift
+      ;;
+    --source)
+      source_path="$2"
+      shift 2
+      ;;
+    --backup)
+      backup_path="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$source_path" ]; then
+  source_path="${target_root}/.claude/sdlc/alphas.md"
+fi
+
+if [ ! -f "$source_path" ]; then
+  echo "migrate-essence: source not found: $source_path" >&2
+  exit 2
+fi
+
+if [ -z "$backup_path" ]; then
+  backup_path="${source_path}.backup-$(date +%Y-%m-%d)"
+fi
+
+case "$mode" in
+  dry-run)
+    npx -y "@ypolosov/sdlc-state-rag-migrate-essence" --source "$source_path" --dry-run
+    ;;
+  verify)
+    npx -y "@ypolosov/sdlc-state-rag-migrate-essence" --source "$source_path" --verify
+    ;;
+  exec)
+    if [ ! -f "$backup_path" ]; then
+      cp -p "$source_path" "$backup_path"
+      echo "migrate-essence: backup written to $backup_path"
+    else
+      echo "migrate-essence: backup already exists at $backup_path (idempotent)" >&2
+    fi
+    npx -y "@ypolosov/sdlc-state-rag-migrate-essence" --source "$source_path" --backup "$backup_path"
+    ;;
+esac

--- a/tests/unit/migrate-essence-to-state-rag.bats
+++ b/tests/unit/migrate-essence-to-state-rag.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$ROOT/scripts/migrate-essence-to-state-rag.sh"
+  TMP_DIR="$(mktemp -d)"
+  TARGET_DIR="$TMP_DIR/target"
+  mkdir -p "$TARGET_DIR/.claude/sdlc"
+  printf 'Альфы\n\n- **opportunity**: Identified\n- **work**: Started\n' \
+    >"$TARGET_DIR/.claude/sdlc/alphas.md"
+  export SDLC_TARGET_ROOT="$TARGET_DIR"
+  export PATH="$TMP_DIR/bin:$PATH"
+  mkdir -p "$TMP_DIR/bin"
+  cat >"$TMP_DIR/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+echo "npx-mock invoked: $*"
+exit 0
+EOF
+  chmod +x "$TMP_DIR/bin/npx"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+@test "script exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "fails on missing source" {
+  run env SDLC_TARGET_ROOT="$TMP_DIR/empty" bash "$SCRIPT" --source "$TMP_DIR/missing.md"
+  [ "$status" -eq 2 ]
+}
+
+@test "dry-run mode invokes npx without backup" {
+  run bash "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "exec mode creates backup before invoking npx" {
+  run bash "$SCRIPT" --exec
+  [ "$status" -eq 0 ]
+  [ -f "$TARGET_DIR/.claude/sdlc/alphas.md.backup-$(date +%Y-%m-%d)" ]
+  [[ "$output" == *"--source"* ]]
+}
+
+@test "exec mode is idempotent on backup" {
+  bash "$SCRIPT" --exec >/dev/null
+  run bash "$SCRIPT" --exec
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+@test "verify mode invokes npx without backup write" {
+  run bash "$SCRIPT" --verify
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--verify"* ]]
+  [ ! -f "$TARGET_DIR/.claude/sdlc/alphas.md.backup-$(date +%Y-%m-%d)" ]
+}
+
+@test "help flag prints usage" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Использование"* ]]
+}


### PR DESCRIPTION
## Summary

Разовая утилита миграции dogfooding-target на новый backend `@ypolosov/sdlc-state-rag` (опубликован v0.1.0).

- `scripts/migrate-essence-to-state-rag.sh` — режимы `--dry-run`, `--verify`, `--exec`.
- `.gitignore`: добавлен `.sdlc-db/` для pglite.
- `tests/unit/migrate-essence-to-state-rag.bats` — 7 кейсов.
- README: scripts 16 → 17.
- CHANGELOG обновлён под Unreleased с BREAKING-секцией для v0.4.0.

## Test plan

- [x] `bats tests/unit/migrate-essence-to-state-rag.bats` — 7/7 зелёные.
- [x] `bash scripts/check-readme-inventory.sh` — OK.
- [ ] CI на PR зелёный.