### PR TITLE
fix(mcp): прямой бинарь sdlc-state-rag вместо npx (v0.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,11 +11,8 @@
     },
     "sdlc-state-rag": {
       "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@ypolosov/sdlc-state-rag"
-      ],
+      "command": "sdlc-state-rag",
+      "args": [],
       "env": {
         "SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-05-05
+
+### Fixed
+
+- `.mcp.json` для `sdlc-state-rag`: `npx -y @ypolosov/sdlc-state-rag` заменён на прямой `sdlc-state-rag` без аргументов. NPX cold-fetch (108 deps включая pglite/pg/pgvector) превышает таймаут health-check Claude Code, плагиновая запись отображается как `Failed to connect`. Та же проблема была у `essence-alpha-mcp` в v0.3.1.
+- README §MCP: требование `npm install -g @ypolosov/sdlc-state-rag` (минимум v0.1.1) перед использованием плагина.
+- `tests/integration/sdlc-state-rag-contract.bats`: новый кейс «.mcp.json uses direct binary not npx» (21-й кейс).
+
 ## [0.5.0] — 2026-05-05
 
 Принцип 22 «Обязательное использование плагина для write-операций» + `enforce-sdlc-phase` PreToolUse hook.
@@ -222,7 +230,8 @@ Multi-agent extension (Wave 4) + sdlc-state-rag (Wave 5).
 - Принципы Волны 1 (1-13 + 4a).
 - Демо-сценарий на todo-list.
 
-[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 - `context7@claude-plugins-official` — референсная документация инструментов (обязательно для SME-опроса).
 - `github@claude-plugins-official` — GitHub Issues как state_artifact для альфы Work (опционально, mid+).
-- `@ypolosov/sdlc-state-rag` — единый backend альф + RAG + decisions + audit + sync (см. ADR-011, Волна 5).
+- `@ypolosov/sdlc-state-rag` — единый backend альф + RAG + decisions + audit + sync (см. ADR-011, Волна 5). **Установка обязательна:** `npm install -g @ypolosov/sdlc-state-rag` (минимум v0.1.1; npx-cold-fetch медленнее MCP health-check таймаута).
 
 Плагин не ship'ит собственный `context7` — используйте dedicated плагин.
 Плагин ship'ит минимальный `github` MCP в `.mcp.json` как fallback.
@@ -166,9 +166,9 @@
   - `check-rag-config.bats` — 8 кейсов на схему rag-config и worker.kind ↔ SME (Волна 5).
   - `migrate-essence-to-state-rag.bats` — 7 кейсов на разовую утилиту миграции (PR-H, Волна 5).
   - `enforce-sdlc-phase.bats` — 10 кейсов на PreToolUse hook принципа 22 (Волна 5, v0.5.0).
-- Integration (bats-core) — `tests/integration/` (3 файла, 44 кейса):
+- Integration (bats-core) — `tests/integration/` (3 файла, 45 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
-  - `sdlc-state-rag-contract.bats` — 20 кейсов на контракт sdlc-state-rag и переключение трекера (Волна 5, ADR-011).
+  - `sdlc-state-rag-contract.bats` — 21 кейс на контракт sdlc-state-rag, переключение трекера и direct-binary registration (Волна 5, ADR-011, v0.5.1).
   - `enforce-sdlc-phase-integration.bats` — 4 кейса на e2e блокировку write-команд при отсутствии `active_phase` (Волна 5, принцип 22).
 - Фикстуры — `tests/fixture/minimal-target/`, `tests/fixture/mid-target/` (валидные каркасы).
 - Статика — `shellcheck` на все скрипты; `shfmt -i 2 -ci` как форматёр.

--- a/tests/integration/sdlc-state-rag-contract.bats
+++ b/tests/integration/sdlc-state-rag-contract.bats
@@ -81,6 +81,11 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test ".mcp.json uses direct binary not npx for sdlc-state-rag (v0.5.1 fix)" {
+  command_value=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(d["mcpServers"]["sdlc-state-rag"]["command"])')
+  [ "$command_value" = "sdlc-state-rag" ]
+}
+
 @test "alpha-tracker uses state_* MCP tools" {
   run grep -E 'mcp__sdlc_state_rag__state_' "$TRACKER"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
**Hotfix v0.5.1.**

Проблема: `npx -y @ypolosov/sdlc-state-rag` в `.mcp.json` приводит к `Failed to connect` — NPX cold-fetch (108 deps) превышает таймаут health-check Claude Code. Та же проблема и аналогичный фикс был у `essence-alpha-mcp` в v0.3.1.

## Изменения

- `.mcp.json`: command=`sdlc-state-rag`, args=`[]`.
- README: `npm install -g @ypolosov/sdlc-state-rag` обязателен.
- `tests/integration/sdlc-state-rag-contract.bats`: +1 кейс direct-binary (20→21).
- README integration count 44→45.
- `plugin.json` 0.5.0 → 0.5.1.
- CHANGELOG `[0.5.1]`.

## Test plan

- [x] 84 unit + 45 integration bats зелёные локально.
- [ ] CI зелёный.
- [ ] После merge — релиз v0.5.1 + перезагрузка Claude Code → MCP `sdlc-state-rag` подключён.