### PR TITLE
fix(mcp): launcher-скрипт sdlc-state-rag для resilience PATH (v0.5.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,7 +11,7 @@
     },
     "sdlc-state-rag": {
       "type": "stdio",
-      "command": "sdlc-state-rag",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh",
       "args": [],
       "env": {
         "SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-05-05
+
+### Fixed
+
+- `.mcp.json` для `sdlc-state-rag`: прямой `command: "sdlc-state-rag"` (v0.5.1) не работает в Claude Code MCP launcher из-за ограниченного PATH (не находит `node` через nvm). Заменено на launcher-скрипт `${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh`, который пытается резолвить бинарь через PATH → nvm.sh → стандартные локации (`/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin`) → fallback на `npx -y`.
+- `scripts/enforce-no-comments.sh`: добавлен whitelist для `# shellcheck` директив (как `# pylint:`, `// eslint-`).
+- `tests/integration/sdlc-state-rag-contract.bats`: 2 новых кейса на launcher-скрипт (21→23 кейса).
+
+### Added
+
+- `scripts/launch-sdlc-state-rag.sh` — launcher с fallback-цепочкой для разных Node-окружений.
+
 ## [0.5.1] — 2026-05-05
 
 ### Fixed
@@ -230,7 +242,8 @@ Multi-agent extension (Wave 4) + sdlc-state-rag (Wave 5).
 - Принципы Волны 1 (1-13 + 4a).
 - Демо-сценарий на todo-list.
 
-[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.3.1...v0.4.0

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 - `sdlc-tool-router` — маршрутизация запросов по категориям к MCP-серверам (Волна 4).
 - `sdlc-context-aggregator` — фасад консолидации контекста с провенансом (Волна 4, ADR-010).
 
-### Scripts (17)
+### Scripts (18)
 - `validate-artifact.sh` — frontmatter, секции, ≤15 слов, русский.
 - `enforce-tdd.sh` — мягкая блокировка записи кода без парного теста.
 - `enforce-format-lint.sh` — диспетчер форматера и линтера из `plugin-config.md`.
@@ -107,6 +107,7 @@
 - `check-rag-config.sh` — валидирует `rag-config.md` целевого и worker.kind ↔ SME (Волна 5, ADR-012).
 - `migrate-essence-to-state-rag.sh` — разовая миграция dogfooding с `--dry-run` / `--verify` / `--exec` (Волна 5, PR-H).
 - `enforce-sdlc-phase.sh` — PreToolUse hook принципа 22; блокирует git/gh/npm write-команды и Edit/Write без `active_phase` (Волна 5, v0.5.0).
+- `launch-sdlc-state-rag.sh` — launcher MCP-сервера sdlc-state-rag с fallback PATH→nvm→standard locations→npx (v0.5.2).
 
 ### Meta-templates (16)
 - `work-product.meta.md` — базовая схема рабочего продукта.
@@ -166,9 +167,9 @@
   - `check-rag-config.bats` — 8 кейсов на схему rag-config и worker.kind ↔ SME (Волна 5).
   - `migrate-essence-to-state-rag.bats` — 7 кейсов на разовую утилиту миграции (PR-H, Волна 5).
   - `enforce-sdlc-phase.bats` — 10 кейсов на PreToolUse hook принципа 22 (Волна 5, v0.5.0).
-- Integration (bats-core) — `tests/integration/` (3 файла, 45 кейсов):
+- Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
-  - `sdlc-state-rag-contract.bats` — 21 кейс на контракт sdlc-state-rag, переключение трекера и direct-binary registration (Волна 5, ADR-011, v0.5.1).
+  - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, launcher-скрипт (Волна 5, ADR-011, v0.5.2).
   - `enforce-sdlc-phase-integration.bats` — 4 кейса на e2e блокировку write-команд при отсутствии `active_phase` (Волна 5, принцип 22).
 - Фикстуры — `tests/fixture/minimal-target/`, `tests/fixture/mid-target/` (валидные каркасы).
 - Статика — `shellcheck` на все скрипты; `shfmt -i 2 -ci` как форматёр.

--- a/scripts/enforce-no-comments.sh
+++ b/scripts/enforce-no-comments.sh
@@ -35,6 +35,7 @@ whitelist+=('^\s*// @ts-')
 whitelist+=('^\s*// eslint-')
 whitelist+=('^\s*/\* eslint-')
 whitelist+=('^\s*// biome-ignore')
+whitelist+=('^\s*# shellcheck')
 
 if [ -f "$config" ]; then
   while IFS= read -r pat; do

--- a/scripts/launch-sdlc-state-rag.sh
+++ b/scripts/launch-sdlc-state-rag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v sdlc-state-rag >/dev/null 2>&1; then
+  exec sdlc-state-rag "$@"
+fi
+
+if [ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
+elif [ -s "$HOME/.nvm/nvm.sh" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
+fi
+
+if command -v sdlc-state-rag >/dev/null 2>&1; then
+  exec sdlc-state-rag "$@"
+fi
+
+for candidate in \
+  /usr/local/bin/sdlc-state-rag \
+  /opt/homebrew/bin/sdlc-state-rag \
+  "$HOME/.local/bin/sdlc-state-rag"; do
+  if [ -x "$candidate" ]; then
+    exec "$candidate" "$@"
+  fi
+done
+
+if command -v npx >/dev/null 2>&1; then
+  exec npx -y @ypolosov/sdlc-state-rag "$@"
+fi
+
+printf 'launch-sdlc-state-rag: не найден ни sdlc-state-rag, ни node/npx.\n' >&2
+printf 'Установите: npm install -g @ypolosov/sdlc-state-rag\n' >&2
+exit 127

--- a/tests/integration/sdlc-state-rag-contract.bats
+++ b/tests/integration/sdlc-state-rag-contract.bats
@@ -81,9 +81,13 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test ".mcp.json uses direct binary not npx for sdlc-state-rag (v0.5.1 fix)" {
+@test ".mcp.json uses launcher script for sdlc-state-rag (v0.5.2 fix)" {
   command_value=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(d["mcpServers"]["sdlc-state-rag"]["command"])')
-  [ "$command_value" = "sdlc-state-rag" ]
+  [[ "$command_value" == *"launch-sdlc-state-rag.sh" ]]
+}
+
+@test "launch-sdlc-state-rag.sh exists and is executable" {
+  [ -x "$PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh" ]
 }
 
 @test "alpha-tracker uses state_* MCP tools" {


### PR DESCRIPTION
**Hotfix v0.5.2.**

v0.5.1 «прямой бинарь» не работает в Claude Code MCP launcher: PATH ограничен и не находит `node` через nvm. Бинарь `sdlc-state-rag` имеет shebang `#!/usr/bin/env node` — без node в PATH запуск падает.

## Решение

`scripts/launch-sdlc-state-rag.sh` — fallback-цепочка:
1. `command -v sdlc-state-rag` (если в PATH).
2. Source `nvm.sh` (через `$NVM_DIR` или `$HOME/.nvm/nvm.sh`).
3. `/usr/local/bin` / `/opt/homebrew/bin` / `$HOME/.local/bin`.
4. `npx -y @ypolosov/sdlc-state-rag` (последний fallback).

`.mcp.json` использует `${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh`.

## Дополнительно

- `enforce-no-comments.sh`: whitelist для `# shellcheck` директив.
- `tests/integration/sdlc-state-rag-contract.bats`: 2 новых кейса (launcher exists/registered).

## Test plan

- [x] Локальный launcher проходит MCP handshake даже с `env -i PATH=/usr/bin:/bin`.
- [x] 84 unit + 47 integration bats зелёные.
- [ ] CI зелёный.
- [ ] После reload Claude Code → `sdlc-state-rag: ✓ Connected`.