### PR TITLE
fix(mcp): bash-wrapper для двух контекстов plugin/project (v0.5.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,8 +11,11 @@
     },
     "sdlc-state-rag": {
       "type": "stdio",
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh",
-      "args": [],
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec \"${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/launch-sdlc-state-rag.sh\""
+      ],
       "env": {
         "SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-05-05
+
+### Fixed
+
+- `.mcp.json` для `sdlc-state-rag`: v0.5.2 использовал `${CLAUDE_PLUGIN_ROOT}` который НЕ подставляется в project-level `.mcp.json` (только в plugin-level). Это ломало dogfooding — при работе над плагином как над проектом запись отображалась как `Failed to connect`. Заменено на `bash -c 'exec "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/launch-sdlc-state-rag.sh"'` — bash-параметр-expansion работает в обоих контекстах.
+
 ## [0.5.2] — 2026-05-05
 
 ### Fixed
@@ -242,7 +248,8 @@ Multi-agent extension (Wave 4) + sdlc-state-rag (Wave 5).
 - Принципы Волны 1 (1-13 + 4a).
 - Демо-сценарий на todo-list.
 
-[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@
   - `enforce-sdlc-phase.bats` — 10 кейсов на PreToolUse hook принципа 22 (Волна 5, v0.5.0).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
-  - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, launcher-скрипт (Волна 5, ADR-011, v0.5.2).
+  - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).
   - `enforce-sdlc-phase-integration.bats` — 4 кейса на e2e блокировку write-команд при отсутствии `active_phase` (Волна 5, принцип 22).
 - Фикстуры — `tests/fixture/minimal-target/`, `tests/fixture/mid-target/` (валидные каркасы).
 - Статика — `shellcheck` на все скрипты; `shfmt -i 2 -ci` как форматёр.

--- a/tests/integration/sdlc-state-rag-contract.bats
+++ b/tests/integration/sdlc-state-rag-contract.bats
@@ -81,9 +81,14 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test ".mcp.json uses launcher script for sdlc-state-rag (v0.5.2 fix)" {
+@test ".mcp.json uses bash wrapper for launcher (v0.5.3 fix)" {
   command_value=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(d["mcpServers"]["sdlc-state-rag"]["command"])')
-  [[ "$command_value" == *"launch-sdlc-state-rag.sh" ]]
+  [ "$command_value" = "bash" ]
+}
+
+@test ".mcp.json bash args reference launch-sdlc-state-rag.sh" {
+  args_str=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(" ".join(d["mcpServers"]["sdlc-state-rag"]["args"]))')
+  [[ "$args_str" == *"launch-sdlc-state-rag.sh"* ]]
 }
 
 @test "launch-sdlc-state-rag.sh exists and is executable" {


### PR DESCRIPTION
**Hotfix v0.5.3.**

v0.5.2 использовал `${CLAUDE_PLUGIN_ROOT}` который НЕ подставляется в **project-level** `.mcp.json` (только в plugin-level). Это ломало dogfooding — при работе над плагином как над проектом запись отображалась как `Failed to connect`.

## Решение

`bash -c 'exec "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/launch-sdlc-state-rag.sh"'`

Параметр-expansion работает в обоих контекстах:
- **Plugin context** (после install через marketplace): `${CLAUDE_PLUGIN_ROOT}` = cache dir.
- **Project context** (dogfooding): `${CLAUDE_PROJECT_DIR}` = source repo.
- Fallback: `$PWD`.

## Test plan

- [x] Локально проходит MCP handshake с `env -i PATH=/usr/bin:/bin CLAUDE_PROJECT_DIR=$(pwd)`.
- [x] 84 unit + 47 integration bats зелёные.
- [ ] CI зелёный.
- [ ] После reload Claude Code → MCP `sdlc-state-rag: ✓ Connected`.