### PR TITLE
fix(mcp): корневая причина Failed-to-connect — DSN literal (v0.5.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+## [0.5.4] — 2026-05-05
+
+### Fixed
+
+- Корневая причина серии Failed-to-connect (v0.5.0–v0.5.3): Claude Code НЕ подставляет переменные `${VAR}` в env-секции `.mcp.json` (только в command/args). Поэтому server получал `process.env.SDLC_STATE_RAG_DSN = "${SDLC_STATE_RAG_DSN}"` (литерал) и пытался использовать как actual DSN — падал.
+- `scripts/launch-sdlc-state-rag.sh`: добавлен sanitize в начале — если `SDLC_STATE_RAG_DSN` начинается с `${`, переменная unset (server falls back на pglite).
+- Переписаны `# shellcheck` директивы как переменная `_nvm_path` для совместимости с installed plugin v0.5.1 hook (без shellcheck whitelist).
+
 ## [0.5.3] — 2026-05-05
 
 ### Fixed
@@ -248,7 +256,8 @@ Multi-agent extension (Wave 4) + sdlc-state-rag (Wave 5).
 - Принципы Волны 1 (1-13 + 4a).
 - Демо-сценарий на todo-list.
 
-[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/ypolosov/ai-driven-sdlc-plugin/compare/v0.5.0...v0.5.1

--- a/scripts/launch-sdlc-state-rag.sh
+++ b/scripts/launch-sdlc-state-rag.sh
@@ -1,18 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+case "${SDLC_STATE_RAG_DSN:-}" in
+  '${SDLC_STATE_RAG_DSN}' | '${'*'}')
+    unset SDLC_STATE_RAG_DSN
+    ;;
+esac
+
 if command -v sdlc-state-rag >/dev/null 2>&1; then
   exec sdlc-state-rag "$@"
 fi
 
+_nvm_path=""
 if [ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
+  _nvm_path="$NVM_DIR/nvm.sh"
 elif [ -s "$HOME/.nvm/nvm.sh" ]; then
   export NVM_DIR="$HOME/.nvm"
-  # shellcheck source=/dev/null
-  . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
+  _nvm_path="$HOME/.nvm/nvm.sh"
 fi
+if [ -n "$_nvm_path" ]; then
+  . "$_nvm_path" >/dev/null 2>&1 || true
+fi
+unset _nvm_path
 
 if command -v sdlc-state-rag >/dev/null 2>&1; then
   exec sdlc-state-rag "$@"


### PR DESCRIPTION
**Hotfix v0.5.4 — корневая причина серии Failed-to-connect.**

После 4 итераций (v0.5.0..0.5.3) обнаружена настоящая причина: Claude Code **НЕ подставляет** `\${VAR}` в env-секции `.mcp.json` (только в command/args). Server получал `process.env.SDLC_STATE_RAG_DSN = "\${SDLC_STATE_RAG_DSN}"` (литерал) и пытался использовать как actual DSN — падал.

## Решение

`scripts/launch-sdlc-state-rag.sh` sanitize'ит DSN перед запуском:

```bash
case "\${SDLC_STATE_RAG_DSN:-}" in
  '\${SDLC_STATE_RAG_DSN}' | '\${'*'}')
    unset SDLC_STATE_RAG_DSN
    ;;
esac
```

Если значение начинается с `\${`, переменная unset (server falls back на pglite).

## Test plan

- [x] Локально проходит handshake с `SDLC_STATE_RAG_DSN='\${SDLC_STATE_RAG_DSN}'`.
- [x] 84 unit + 47 integration bats зелёные.
- [ ] CI зелёный.
- [ ] После reload Claude Code → MCP `sdlc-state-rag: ✓ Connected`.