### PR TITLE
feat(wave-6): pre-validation fixes A1 + A2 для enterprise-применения

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-05-10
+
+### Added
+
+- **Fix A2 (P0)**: `scripts/bootstrap-target.sh` авто-создаёт `<target>/.mcp.json` с записью `sdlc-state-rag` в режиме strict-merge. Если файл существует — добавляет entry; если есть `sdlc-state-rag` — keep по умолчанию, overwrite через `MCP_OVERWRITE_SDLC_RAG=yes`. Соблюдает принцип 21 (per-target instance MCP).
+- **Fix A1 (P0)**: поле `adr_paths` в `meta-templates/plugin-config.meta.md` — массив путей к каталогам ADR. Default `[phases/architecture/adr/]` (greenfield). Поддерживает existing-проекты с собственной структурой (например `[docs/adrs/]` для gt-style monorepo).
+- `scripts/check-adr-paths.sh` — валидация поля; exit 2 при несуществующих путях. Default-mode совместимость.
+- `tests/unit/init-mcp-json.bats` — 5 кейсов: greenfield / existing-without-sdlc / existing-with-sdlc-overwrite / existing-with-sdlc-keep / invalid-JSON.
+- `tests/unit/plugin-config-adr-paths.bats` — 5 кейсов: missing-field / block-style / flow-style / non-existent-path / executable.
+- `agents/sdlc-context-aggregator.md` — раздел «Подготовка» извлекает `adr_paths` из plugin-config.
+
+### Changed
+
+- README inventory: Scripts 18→19 (+`check-adr-paths.sh`); Unit tests 11→13 файлов, 84→94 кейса.
+- `meta-templates/plugin-config.meta.md` — добавлен раздел `adr_paths` (Волна 6).
+
+### Why
+
+Pre-validation для Wave 6 gt-experiment: enterprise-проекты часто имеют собственную структуру ADR (`docs/adrs/`, `architecture/decisions/`), плагин её не учитывал. И `.mcp.json` не создавался в target → MCP-сервер `sdlc-state-rag` запускался не per-target. Оба issue блокировали enterprise-применение плагина без ручных обходов.
+
 ## [0.5.4] — 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 - `sdlc-tool-router` — маршрутизация запросов по категориям к MCP-серверам (Волна 4).
 - `sdlc-context-aggregator` — фасад консолидации контекста с провенансом (Волна 4, ADR-010).
 
-### Scripts (18)
+### Scripts (19)
 - `validate-artifact.sh` — frontmatter, секции, ≤15 слов, русский.
 - `enforce-tdd.sh` — мягкая блокировка записи кода без парного теста.
 - `enforce-format-lint.sh` — диспетчер форматера и линтера из `plugin-config.md`.
@@ -108,6 +108,7 @@
 - `migrate-essence-to-state-rag.sh` — разовая миграция dogfooding с `--dry-run` / `--verify` / `--exec` (Волна 5, PR-H).
 - `enforce-sdlc-phase.sh` — PreToolUse hook принципа 22; блокирует git/gh/npm write-команды и Edit/Write без `active_phase` (Волна 5, v0.5.0).
 - `launch-sdlc-state-rag.sh` — launcher MCP-сервера sdlc-state-rag с fallback PATH→nvm→standard locations→npx (v0.5.2).
+- `check-adr-paths.sh` — валидирует `adr_paths` в `plugin-config.md` целевого (Волна 6, v0.6.0).
 
 ### Meta-templates (16)
 - `work-product.meta.md` — базовая схема рабочего продукта.
@@ -155,7 +156,7 @@
 
 Пирамида автотестов по фазе testing (уровень mid).
 
-- Unit (bats-core) — `tests/unit/` (11 файлов, 84 кейса):
+- Unit (bats-core) — `tests/unit/` (13 файлов, 94 кейса):
   - `validate-artifact.bats` — 7 кейсов на поведение валидатора.
   - `check-cross-refs.bats` — 6 кейсов на детектор осиротевших ссылок.
   - `enforce-no-comments.bats` — 9 кейсов (включая TypeScript whitelist Wave 5).
@@ -167,6 +168,8 @@
   - `check-rag-config.bats` — 8 кейсов на схему rag-config и worker.kind ↔ SME (Волна 5).
   - `migrate-essence-to-state-rag.bats` — 7 кейсов на разовую утилиту миграции (PR-H, Волна 5).
   - `enforce-sdlc-phase.bats` — 10 кейсов на PreToolUse hook принципа 22 (Волна 5, v0.5.0).
+  - `init-mcp-json.bats` — 5 кейсов на авто-создание/мердж `.mcp.json` в target (Волна 6, v0.6.0).
+  - `plugin-config-adr-paths.bats` — 5 кейсов на валидацию `adr_paths` в plugin-config (Волна 6, v0.6.0).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/agents/sdlc-context-aggregator.md
+++ b/agents/sdlc-context-aggregator.md
@@ -27,6 +27,7 @@ Skills не вызывают MCP напрямую; запрашивают кон
 - Прочитать `<target_dir>/.claude/sdlc/plugin-config.md`.
 - Если файл отсутствует — отказать.
 - Извлечь `rag_ref.enabled` (Волна 5) и `tool_bindings`.
+- Извлечь `adr_paths` (Волна 6); default `[phases/architecture/adr/]`.
 - Определить `rag_enabled` (default: false).
 
 ### 2. Запрос RAG (если включён)
@@ -106,7 +107,7 @@ Skills не вызывают MCP напрямую; запрашивают кон
 ## Связь
 
 - Источники — `sdlc-tool-router`, `sdlc-state-reader`, `sdlc-alpha-tracker`, RAG MCP.
-- Конфиг — `meta-templates/plugin-config.meta.md` (секции `tool_bindings`, `rag_ref`).
+- Конфиг — `meta-templates/plugin-config.meta.md` (секции `tool_bindings`, `rag_ref`, `adr_paths`).
 - Принципы — 1 (AskUserQuestion), 13 (нет обхода трекера), 18 (категории), 19 (провенанс), 19a (MCP до RAG).
 - ADR — ADR-010 (multi-agent topology).
 - Закрывает epic #7 (параллельная работа), готовит epic #10 (evolution-фаза).

--- a/meta-templates/plugin-config.meta.md
+++ b/meta-templates/plugin-config.meta.md
@@ -157,6 +157,29 @@ phase_enforcement:
 `SDLC_PHASE_ENFORCE=skip` — escape hatch для CI.
 Эфемерный override — через `/sdlc-autonomy --task hootl --duration <N>m` пишет `.claude/sdlc/autonomy.session.md`.
 
+### adr_paths (Волна 6, опционально)
+
+Пути к каталогам ADR в целевом проекте.
+Поддерживает greenfield-таргеты и existing-таргеты с собственной структурой docs/.
+
+```yaml
+adr_paths:
+  - phases/architecture/adr/
+```
+
+Default при отсутствии поля: `[phases/architecture/adr/]`.
+Для existing-проектов с собственной структурой:
+
+```yaml
+adr_paths:
+  - docs/adrs/
+  - devops/configuration/decisions/
+```
+
+Поля массив строк; пути относительные к корню целевого.
+`scripts/check-adr-paths.sh` валидирует существование путей; exit 2 при несуществующем.
+`agents/sdlc-context-aggregator.md` сканирует все пути при чтении ADR.
+
 ### workers (Волна 5, опционально)
 
 Конфигурация worker'ов синхронизации.

--- a/scripts/bootstrap-target.sh
+++ b/scripts/bootstrap-target.sh
@@ -111,5 +111,53 @@ if ! grep -qE '^\.env$' "$gitignore"; then
 EOF
 fi
 
+mcp_json="${target}/.mcp.json"
+overwrite_mode="${MCP_OVERWRITE_SDLC_RAG:-no}"
+TARGET_MCP_JSON="$mcp_json" OVERWRITE_MODE="$overwrite_mode" python3 - <<'PY'
+import json
+import os
+import sys
+
+target_path = os.environ['TARGET_MCP_JSON']
+overwrite = os.environ.get('OVERWRITE_MODE', 'no')
+
+new_entry = {
+    "type": "stdio",
+    "command": "bash",
+    "args": [
+        "-c",
+        'exec "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/launch-sdlc-state-rag.sh"',
+    ],
+    "env": {"SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"},
+}
+
+if os.path.exists(target_path):
+    try:
+        with open(target_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f'bootstrap-target: некорректный JSON в {target_path}: {exc}\n')
+        sys.exit(2)
+    if not isinstance(data, dict):
+        sys.stderr.write(f'bootstrap-target: {target_path} не объект JSON\n')
+        sys.exit(2)
+    servers = data.setdefault('mcpServers', {})
+    if not isinstance(servers, dict):
+        sys.stderr.write(f'bootstrap-target: mcpServers не объект в {target_path}\n')
+        sys.exit(2)
+    if 'sdlc-state-rag' in servers and overwrite != 'yes':
+        pass
+    else:
+        servers['sdlc-state-rag'] = new_entry
+    with open(target_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+else:
+    data = {'mcpServers': {'sdlc-state-rag': new_entry}}
+    with open(target_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+PY
+
 printf 'bootstrap-target: %s инициализирован в режиме %s.\n' "$sdlc_dir" "$mode"
 exit 0

--- a/scripts/check-adr-paths.sh
+++ b/scripts/check-adr-paths.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:-$PWD}"
+config="${target}/.claude/sdlc/plugin-config.md"
+
+if [ ! -f "$config" ]; then
+  exit 0
+fi
+
+result="$(
+  TARGET_CONFIG="$config" python3 - <<'PY'
+import os
+import re
+import sys
+
+config_path = os.environ['TARGET_CONFIG']
+with open(config_path, 'r', encoding='utf-8') as f:
+    content = f.read()
+
+flow = re.search(r'^adr_paths:\s*\[([^\]]*)\]', content, re.MULTILINE)
+block = re.search(r'^adr_paths:\s*\n((?:[ \t]+-[ \t]*\S.*\n)+)', content, re.MULTILINE)
+
+paths = []
+if flow:
+    raw = flow.group(1)
+    paths = [p.strip().strip("'").strip('"') for p in raw.split(',') if p.strip()]
+elif block:
+    for line in block.group(1).split('\n'):
+        m = re.match(r'\s*-\s*(.+)', line)
+        if m:
+            v = m.group(1).strip().strip("'").strip('"')
+            if v:
+                paths.append(v)
+
+if not paths:
+    print("DEFAULT")
+else:
+    print("|".join(paths))
+PY
+)"
+
+if [ "$result" = "DEFAULT" ]; then
+  paths=("phases/architecture/adr/")
+else
+  IFS='|' read -ra paths <<<"$result"
+fi
+
+errors=0
+for p in "${paths[@]}"; do
+  full_path="${target}/${p}"
+  if [ ! -d "$full_path" ]; then
+    printf 'check-adr-paths: путь не существует: %s\n' "$full_path" >&2
+    errors=$((errors + 1))
+  fi
+done
+
+if [ "$errors" -gt 0 ]; then
+  printf 'Найдено %s несуществующих ADR-путей.\n' "$errors" >&2
+  exit 2
+fi
+
+exit 0

--- a/tests/unit/init-mcp-json.bats
+++ b/tests/unit/init-mcp-json.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$ROOT/scripts/bootstrap-target.sh"
+  TMP_DIR="$(mktemp -d)"
+  TARGET_DIR="$TMP_DIR/target"
+  mkdir -p "$TARGET_DIR"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+@test "greenfield: creates .mcp.json with sdlc-state-rag entry" {
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  [ -f "$TARGET_DIR/.mcp.json" ]
+  python3 -c "
+import json
+d = json.load(open('$TARGET_DIR/.mcp.json'))
+assert 'mcpServers' in d, 'mcpServers missing'
+assert 'sdlc-state-rag' in d['mcpServers'], 'sdlc-state-rag missing'
+entry = d['mcpServers']['sdlc-state-rag']
+assert entry['command'] == 'bash', f'expected bash, got {entry[\"command\"]}'
+assert 'launch-sdlc-state-rag.sh' in ' '.join(entry['args']), 'launcher missing'
+"
+}
+
+@test "existing .mcp.json without sdlc-state-rag: adds entry, preserves others" {
+  cat >"$TARGET_DIR/.mcp.json" <<'EOF'
+{"mcpServers": {"github": {"command": "gh-mcp", "args": ["serve"]}}}
+EOF
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  python3 -c "
+import json
+d = json.load(open('$TARGET_DIR/.mcp.json'))
+assert 'github' in d['mcpServers'], 'github entry lost'
+assert 'sdlc-state-rag' in d['mcpServers'], 'sdlc-state-rag not added'
+assert d['mcpServers']['github']['command'] == 'gh-mcp', 'github command changed'
+"
+}
+
+@test "existing .mcp.json with sdlc-state-rag overwrite=yes: replaces entry" {
+  cat >"$TARGET_DIR/.mcp.json" <<'EOF'
+{"mcpServers": {"sdlc-state-rag": {"command": "old-binary", "args": []}}}
+EOF
+  run env MCP_OVERWRITE_SDLC_RAG=yes bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  python3 -c "
+import json
+d = json.load(open('$TARGET_DIR/.mcp.json'))
+entry = d['mcpServers']['sdlc-state-rag']
+assert entry['command'] == 'bash', f'expected bash overwrite, got {entry[\"command\"]}'
+"
+}
+
+@test "existing .mcp.json with sdlc-state-rag default (keep): preserves entry" {
+  cat >"$TARGET_DIR/.mcp.json" <<'EOF'
+{"mcpServers": {"sdlc-state-rag": {"command": "old-binary", "args": []}}}
+EOF
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  python3 -c "
+import json
+d = json.load(open('$TARGET_DIR/.mcp.json'))
+entry = d['mcpServers']['sdlc-state-rag']
+assert entry['command'] == 'old-binary', f'expected preserved, got {entry[\"command\"]}'
+"
+}
+
+@test "existing .mcp.json with invalid JSON: fails with exit 2" {
+  echo "{ this is not valid json" >"$TARGET_DIR/.mcp.json"
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid"* ]] || [[ "$output" == *"некорректн"* ]] || [[ "$output" == *".mcp.json"* ]]
+}

--- a/tests/unit/plugin-config-adr-paths.bats
+++ b/tests/unit/plugin-config-adr-paths.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$ROOT/scripts/check-adr-paths.sh"
+  TMP_DIR="$(mktemp -d)"
+  TARGET_DIR="$TMP_DIR/target"
+  mkdir -p "$TARGET_DIR/.claude/sdlc"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+@test "script exists and is executable" {
+  [ -f "$SCRIPT" ]
+  [ -x "$SCRIPT" ]
+}
+
+@test "missing adr_paths field: uses default phases/architecture/adr/, exit 0" {
+  cat >"$TARGET_DIR/.claude/sdlc/plugin-config.md" <<'EOF'
+---
+name: plugin-config
+type: hooks-config
+version: 1
+updated: 2026-05-10
+---
+
+state_artifact:
+  kind: file
+  ref: TODO.md
+EOF
+  mkdir -p "$TARGET_DIR/phases/architecture/adr"
+  run "$SCRIPT" "$TARGET_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "adr_paths block-style array with valid paths: exit 0" {
+  mkdir -p "$TARGET_DIR/docs/adrs"
+  mkdir -p "$TARGET_DIR/devops/configuration/decisions"
+  cat >"$TARGET_DIR/.claude/sdlc/plugin-config.md" <<'EOF'
+---
+name: plugin-config
+type: hooks-config
+version: 1
+updated: 2026-05-10
+---
+
+adr_paths:
+  - docs/adrs/
+  - devops/configuration/decisions/
+EOF
+  run "$SCRIPT" "$TARGET_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "adr_paths flow-style with valid path: exit 0" {
+  mkdir -p "$TARGET_DIR/docs/adrs"
+  cat >"$TARGET_DIR/.claude/sdlc/plugin-config.md" <<'EOF'
+---
+name: plugin-config
+type: hooks-config
+version: 1
+updated: 2026-05-10
+---
+
+adr_paths: [docs/adrs/]
+EOF
+  run "$SCRIPT" "$TARGET_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "adr_paths with non-existent path: exit 2" {
+  cat >"$TARGET_DIR/.claude/sdlc/plugin-config.md" <<'EOF'
+---
+name: plugin-config
+type: hooks-config
+version: 1
+updated: 2026-05-10
+---
+
+adr_paths:
+  - missing/path/
+EOF
+  run "$SCRIPT" "$TARGET_DIR"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"missing/path"* ]]
+}


### PR DESCRIPTION
## Summary

Wave 6 Phase 1: P0-блокеры для enterprise-сценария устранены.

- **Fix A2**: `/sdlc-init` авто-создаёт `<target>/.mcp.json` с `sdlc-state-rag` (strict merge). Соблюдает принцип 21 (per-target instance).
- **Fix A1**: поле `adr_paths` (массив) в `plugin-config.md` — поддерживает existing-проекты с собственной структурой docs/adrs/.

## Why

Критический аудит плана Wave 6 (gt-validation) выявил два P0-блокера: enterprise-проекты часто имеют ADR в `docs/adrs/` (не `phases/architecture/adr/`), и `.mcp.json` не создавался автоматически в target. Без фиксов validation требовала бы ручных обходов.

## Changes

- `scripts/bootstrap-target.sh` — JSON merge logic (Python heredoc).
- `scripts/check-adr-paths.sh` — новая валидация поля.
- `meta-templates/plugin-config.meta.md` — раздел `adr_paths` (Волна 6).
- `agents/sdlc-context-aggregator.md` — извлекает `adr_paths` в шаге «Подготовка».
- `README.md` — Scripts 18→19; Unit tests 11→13 файлов / 84→94 кейса.
- `CHANGELOG.md` — секция [0.6.0].
- `.claude-plugin/plugin.json` — 0.5.4 → 0.6.0.

## Tests

- `tests/unit/init-mcp-json.bats` — 5 кейсов.
- `tests/unit/plugin-config-adr-paths.bats` — 5 кейсов.
- Все 94 unit + 47 integration зелёные.
- `bash scripts/check-readme-inventory.sh` — OK.
- `bash scripts/bench-hooks.sh` — все hooks <200ms.

## Test plan

- [x] `bats tests/unit/init-mcp-json.bats` — 5/5 GREEN
- [x] `bats tests/unit/plugin-config-adr-paths.bats` — 5/5 GREEN
- [x] `bats tests/unit/` — 94/94 GREEN
- [x] `bats tests/integration/` — 47/47 GREEN
- [x] `shellcheck scripts/check-adr-paths.sh` — clean
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [x] `bash scripts/bench-hooks.sh` — все <200ms
- [ ] CI зелёный
- [ ] После merge — release `release/v0.6.0` с тегом v0.6.0

## Phase 2 next

После merge — gt-validation в worktree:
1. `git worktree add ~/DEV/GITS/gt-sdlc-experiment experiment/sdlc-plugin-validation`
2. `/sdlc-init` в gt-experiment с фиксами A1/A2
3. Walkthrough 3 фаз (vision/requirements/architecture) на synthetic feature
4. Documenting gaps → backlog Wave 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)