### PR TITLE
feat(wave-7): hook fixes Gap-0 + Gap-2 для unblock dogfooding

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-10
+
+### Fixed
+
+- **Gap-0 (#55, P1)**: hook `enforce-sdlc-phase.sh` теперь проверяет realpath(file_path) относительно cwd. Файлы вне CWD-tree (например `~/.claude/plans/foo.md`) не блокируются hook'ом. Снимает workaround через HOOTL-override для plan-files и других external paths.
+- **Gap-2 (#56, P1)**: hook `enforce-no-comments.sh` распознаёт heredoc-блоки (`<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`) и пропускает их при поиске комментариев. Markdown-заголовки и hash-content в heredocs больше не дают false-positive.
+
+### Added
+
+- `tests/unit/enforce-sdlc-phase.bats` — 2 новых кейса (file outside CWD / file inside CWD).
+- `tests/unit/enforce-no-comments.bats` — 4 новых кейса (heredoc with markdown / heredoc with hash / comment outside heredoc / multiple heredocs).
+
+### Changed
+
+- `scripts/enforce-no-comments.sh` — внутренняя реализация переписана на Python heredoc для парсинга bash-heredoc-блоков.
+- README inventory: Unit tests 94→100 кейсов; `enforce-no-comments.bats` 9→13; `enforce-sdlc-phase.bats` 10→12.
+
+### Why
+
+Wave 6 gt-validation выявила 2 P1 hook-issues. Gap-0 блокировал работу с plan-файлами в `~/.claude/plans/` без override. Gap-2 давал false-positive при редактировании bash-скриптов с heredocs (CLAUDE.md / .gitignore template content). Оба фикса разблокируют dogfooding-разработку плагина.
+
 ## [0.6.0] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@
 
 Пирамида автотестов по фазе testing (уровень mid).
 
-- Unit (bats-core) — `tests/unit/` (13 файлов, 94 кейса):
+- Unit (bats-core) — `tests/unit/` (13 файлов, 100 кейсов):
   - `validate-artifact.bats` — 7 кейсов на поведение валидатора.
   - `check-cross-refs.bats` — 6 кейсов на детектор осиротевших ссылок.
-  - `enforce-no-comments.bats` — 9 кейсов (включая TypeScript whitelist Wave 5).
+  - `enforce-no-comments.bats` — 13 кейсов (TypeScript whitelist Wave 5 + heredoc detection Wave 7).
   - `bootstrap-dev-env.bats` — 3 кейса на детектор пакетного менеджера.
   - `check-alpha-consistency.bats` — 5 кейсов на валидатор БД через `SDLC_STATE_RAG_VALIDATE_CMD`.
   - `check-tool-binding.bats` — 9 кейсов на проверку категорий tool-bindings (Волна 4).
@@ -167,7 +167,7 @@
   - `detect-credentials.bats` — 6 кейсов на проверку `.env` и обязательных ключей (Волна 4).
   - `check-rag-config.bats` — 8 кейсов на схему rag-config и worker.kind ↔ SME (Волна 5).
   - `migrate-essence-to-state-rag.bats` — 7 кейсов на разовую утилиту миграции (PR-H, Волна 5).
-  - `enforce-sdlc-phase.bats` — 10 кейсов на PreToolUse hook принципа 22 (Волна 5, v0.5.0).
+  - `enforce-sdlc-phase.bats` — 12 кейсов на PreToolUse hook принципа 22 (Волна 5 v0.5.0 + realpath fix Wave 7).
   - `init-mcp-json.bats` — 5 кейсов на авто-создание/мердж `.mcp.json` в target (Волна 6, v0.6.0).
   - `plugin-config-adr-paths.bats` — 5 кейсов на валидацию `adr_paths` в plugin-config (Волна 6, v0.6.0).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):

--- a/scripts/enforce-no-comments.sh
+++ b/scripts/enforce-no-comments.sh
@@ -7,7 +7,7 @@ file_path="$(printf '%s' "$payload" | python3 -c 'import sys,json;d=json.load(sy
 cwd="$(printf '%s' "$payload" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("cwd",""))')"
 
 case "$tool_name" in
-  Write|Edit) ;;
+  Write | Edit) ;;
   *) exit 0 ;;
 esac
 
@@ -17,7 +17,7 @@ case "$file_path" in
 esac
 
 case "$file_path" in
-  *.md|*.yml|*.yaml|*.json|*/.gitignore|*/.env.example|*/.env) exit 0 ;;
+  *.md | *.yml | *.yaml | *.json | */.gitignore | */.env.example | */.env) exit 0 ;;
 esac
 
 [ -f "$file_path" ] || exit 0
@@ -45,31 +45,59 @@ if [ -f "$config" ]; then
   done < <(awk '/^no_comments_whitelist:/{flag=1;next} flag&&/^[^[:space:]-]/{flag=0} flag' "$config" | grep -E "^\s*-")
 fi
 
-violations=0
-while IFS= read -r line_raw; do
-  ln=${line_raw%%:*}
-  rest=${line_raw#*:}
+whitelist_joined="$(printf '%s\n' "${whitelist[@]}")"
+SCAN_FILE="$file_path" SCAN_WHITELIST="$whitelist_joined" python3 - <<'PY'
+import os
+import re
+import sys
 
-  if [[ "$rest" =~ ^[[:space:]]*$ ]]; then continue; fi
+file_path = os.environ['SCAN_FILE']
+whitelist_raw = os.environ.get('SCAN_WHITELIST', '')
+whitelist = [re.compile(p) for p in whitelist_raw.splitlines() if p.strip()]
 
-  allowed=0
-  for pat in "${whitelist[@]}"; do
-    if [[ "$rest" =~ $pat ]]; then
-      allowed=1
-      break
-    fi
-  done
-  [ "$allowed" = "1" ] && continue
+with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+    lines = f.readlines()
 
-  if [[ "$rest" =~ ^[[:space:]]*// ]] || [[ "$rest" =~ ^[[:space:]]*# ]] || [[ "$rest" =~ ^[[:space:]]*/\* ]] || [[ "$rest" =~ ^[[:space:]]*\*/[[:space:]]*$ ]]; then
-    printf 'no-comments: %s:%s содержит комментарий.\n' "$file_path" "$ln" >&2
-    violations=$((violations+1))
-  fi
-done < <(grep -nE '^\s*(//|#|/\*|\*/)' "$file_path" || true)
+heredoc_re = re.compile(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?")
+in_heredoc = False
+delimiter = None
+allow_indent = False
 
-if [ "$violations" -gt 0 ]; then
-  printf 'Принцип 4a: код без комментариев. Уберите %s комментариев.\n' "$violations" >&2
-  exit 2
-fi
+violations = []
+for idx, line in enumerate(lines, start=1):
+    if in_heredoc:
+        stripped = line.rstrip('\n')
+        check = stripped.lstrip() if allow_indent else stripped
+        if check == delimiter:
+            in_heredoc = False
+            delimiter = None
+            allow_indent = False
+        continue
+    m = heredoc_re.search(line)
+    if m:
+        delimiter = m.group(1)
+        allow_indent = '<<-' in line[: m.start() + 3]
+        in_heredoc = True
+        continue
+    if not re.match(r'^\s*(//|#|/\*|\*/)', line):
+        continue
+    if line.strip() == '':
+        continue
+    matched_white = False
+    for pat in whitelist:
+        if pat.search(line):
+            matched_white = True
+            break
+    if matched_white:
+        continue
+    if re.match(r'^\s*//', line) or re.match(r'^\s*#', line) or re.match(r'^\s*/\*', line) or re.match(r'^\s*\*/\s*$', line):
+        violations.append(idx)
 
-exit 0
+for ln in violations:
+    sys.stderr.write(f'no-comments: {file_path}:{ln} содержит комментарий.\n')
+
+if violations:
+    sys.stderr.write(f'Принцип 4a: код без комментариев. Уберите {len(violations)} комментариев.\n')
+    sys.exit(2)
+sys.exit(0)
+PY

--- a/scripts/enforce-sdlc-phase.sh
+++ b/scripts/enforce-sdlc-phase.sh
@@ -64,7 +64,15 @@ if tool_name in ("Write", "Edit"):
   if not file_path:
     print("OK")
     sys.exit(0)
-  rel = os.path.relpath(file_path, cwd) if file_path.startswith(cwd) else file_path
+  abs_file = os.path.abspath(file_path)
+  abs_cwd = os.path.abspath(cwd)
+  try:
+    rel = os.path.relpath(abs_file, abs_cwd)
+  except ValueError:
+    rel = abs_file
+  if rel.startswith(".."):
+    print("OK")
+    sys.exit(0)
   if in_whitelist_path(rel):
     print("OK")
     sys.exit(0)

--- a/tests/unit/enforce-no-comments.bats
+++ b/tests/unit/enforce-no-comments.bats
@@ -66,3 +66,54 @@ payload() {
   run bash -c "printf '%s' '$(payload Write "$TMP_DIR/file.ts" "$TMP_DIR")' | '$SCRIPT'"
   [ "$status" -ne 0 ]
 }
+
+@test "heredoc with markdown headers does not trigger (Gap-2 fix)" {
+  cat >"$TMP_DIR/with-heredoc.sh" <<'OUTER'
+#!/usr/bin/env bash
+cat >"$1" <<'EOF'
+# Markdown Header
+## Section
+EOF
+OUTER
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/with-heredoc.sh" "$TMP_DIR")' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "heredoc with bash-style hash comments inside is not flagged (Gap-2 fix)" {
+  cat >"$TMP_DIR/heredoc-hash.sh" <<'OUTER'
+#!/usr/bin/env bash
+cat >"$1" <<EOF
+# This is content of generated file
+.env
+.env.local
+EOF
+OUTER
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/heredoc-hash.sh" "$TMP_DIR")' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "comment OUTSIDE heredoc is still flagged (Gap-2 fix)" {
+  cat >"$TMP_DIR/mixed.sh" <<'OUTER'
+#!/usr/bin/env bash
+# this is a real bash comment
+cat >"$1" <<'EOF'
+# This is heredoc content
+EOF
+OUTER
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/mixed.sh" "$TMP_DIR")' | '$SCRIPT'"
+  [ "$status" -ne 0 ]
+}
+
+@test "multiple heredocs all ignored (Gap-2 fix)" {
+  cat >"$TMP_DIR/multi.sh" <<'OUTER'
+#!/usr/bin/env bash
+cat >"$1" <<EOF
+# First heredoc content
+EOF
+cat >"$2" <<EOF
+# Second heredoc content
+EOF
+OUTER
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/multi.sh" "$TMP_DIR")' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/unit/enforce-sdlc-phase.bats
+++ b/tests/unit/enforce-sdlc-phase.bats
@@ -109,3 +109,17 @@ EOF
   [ "$status" -eq 2 ]
   [[ "$output" == *"sdlc"* ]]
 }
+
+@test "Edit on file outside CWD-tree passes (Gap-0 fix)" {
+  outside_dir="$(mktemp -d)"
+  outside_file="$outside_dir/external.md"
+  printf 'content\n' >"$outside_file"
+  run bash -c "printf '%s' '$(payload Edit '{"file_path":"'"$outside_file"'"}')' | '$SCRIPT'"
+  rm -rf "$outside_dir"
+  [ "$status" -eq 0 ]
+}
+
+@test "Edit on absolute path inside CWD still requires active_phase" {
+  run bash -c "printf '%s' '$(payload Edit '{"file_path":"'"$TARGET_DIR"'/src/foo.ts"}')' | '$SCRIPT'"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Закрывает 2 P1 hook-issues из Wave 6 gt-validation backlog. Оба разблокируют dogfooding-разработку плагина.

- **#55 Gap-0**: `enforce-sdlc-phase.sh` использует realpath(file_path) → файлы вне CWD-tree пропускаются.
- **#56 Gap-2**: `enforce-no-comments.sh` распознаёт heredoc-блоки → false-positive снят.

## Why

Оба gap наблюдались в этой же сессии при разработке v0.6.0:
- Gap-0 блокировал Edit на `~/.claude/plans/<file>.md` без HOOTL-override (приходилось каждый раз обновлять active_phase).
- Gap-2 давал false-positive при Edit на `bootstrap-target.sh` (heredoc для CLAUDE.md template содержит markdown headers `# Title`).

После фиксов dogfooding-разработка плагина не требует постоянных override.

## Tests

- Unit total: 94 → 100 кейсов.
- `enforce-sdlc-phase.bats`: 10 → 12 (+ realpath cases).
- `enforce-no-comments.bats`: 9 → 13 (+ heredoc cases).
- Все 100 unit + 47 integration GREEN.
- `bash scripts/check-readme-inventory.sh` — OK.
- `bash scripts/bench-hooks.sh` — все hooks <200ms.
- shellcheck clean.

## Test plan

- [x] `bats tests/unit/enforce-sdlc-phase.bats` — 12/12 GREEN
- [x] `bats tests/unit/enforce-no-comments.bats` — 13/13 GREEN
- [x] `bats tests/unit/` — 100/100 GREEN
- [x] `bats tests/integration/` — 47/47 GREEN
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [x] `bash scripts/bench-hooks.sh` — все <200ms
- [x] shellcheck clean
- [ ] CI зелёный
- [ ] После merge — release v0.7.0

Closes #55, #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)