### PR TITLE
feat(wave-7): Gap-4 bootstrap создаёт role-extensions.md placeholder

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-10
+
+### Added
+
+- **Gap-4 (#57, P1)**: `scripts/bootstrap-target.sh` создаёт `<target>/.claude/sdlc/role-extensions.md` placeholder в момент инициализации. Содержит схему `target-role-mapping` (frontmatter type), human-readable инструкцию и пример pet-role `solo-developer extends [product-owner, architect, developer, tester, devops]`. Позволяет greenfield-таргетам сразу видеть формат role-расширений без чтения catalogs/.
+- `tests/unit/bootstrap-role-extensions.bats` — 4 кейса (file exists / type frontmatter / name+project / merge-mode preserves existing).
+
+### Changed
+
+- README inventory: Unit tests 100→104 кейсов; +`bootstrap-role-extensions.bats` (4 кейса).
+
+### Why
+
+Wave 6 gt-validation выявила что bootstrap не создавал `role-extensions.md`, хотя ADR-015 определяет его как обязательный артефакт `.claude/sdlc/`. Для enterprise-проектов user должен был писать его вручную после `/sdlc-init`. Теперь bootstrap создаёт минимально-валидный placeholder.
+
 ## [0.7.0] — 2026-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@
 
 Пирамида автотестов по фазе testing (уровень mid).
 
-- Unit (bats-core) — `tests/unit/` (13 файлов, 100 кейсов):
+- Unit (bats-core) — `tests/unit/` (14 файлов, 104 кейсa):
   - `validate-artifact.bats` — 7 кейсов на поведение валидатора.
   - `check-cross-refs.bats` — 6 кейсов на детектор осиротевших ссылок.
   - `enforce-no-comments.bats` — 13 кейсов (TypeScript whitelist Wave 5 + heredoc detection Wave 7).
@@ -170,6 +170,7 @@
   - `enforce-sdlc-phase.bats` — 12 кейсов на PreToolUse hook принципа 22 (Волна 5 v0.5.0 + realpath fix Wave 7).
   - `init-mcp-json.bats` — 5 кейсов на авто-создание/мердж `.mcp.json` в target (Волна 6, v0.6.0).
   - `plugin-config-adr-paths.bats` — 5 кейсов на валидацию `adr_paths` в plugin-config (Волна 6, v0.6.0).
+  - `bootstrap-role-extensions.bats` — 4 кейса на создание `role-extensions.md` placeholder при /sdlc-init (Волна 7, v0.8.0).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/scripts/bootstrap-target.sh
+++ b/scripts/bootstrap-target.sh
@@ -91,6 +91,47 @@ Placeholder. Заполняется skill \`sdlc-bootstrap\` через /sdlc-in
 EOF
 done
 
+role_ext_dest="${sdlc_dir}/role-extensions.md"
+if [ ! -f "$role_ext_dest" ]; then
+  cat > "$role_ext_dest" <<EOF
+---
+name: role-extensions
+type: target-role-mapping
+project: $(basename "$target")
+created: $(date +%Y-%m-%d)
+updated: $(date +%Y-%m-%d)
+---
+
+# Role extensions целевого проекта
+
+Маппинг конкретных ролей команды на 9 абстрактных ролей плагина (см. \`catalogs/roles.md\`).
+
+Для greenfield-проектов начните с одной записи; расширяйте по мере роста команды.
+
+## Запись роли
+
+\`\`\`yaml
+- id: <slug>
+  title: <human-readable>
+  extends: [<abstract-role>, ...]
+  agent_kind: human | ai | both
+  tool_categories: [<id>, ...]
+  phases: [<phase>, ...]
+  alphas: [<alpha>, ...]
+\`\`\`
+
+## Пример (pet, solo developer)
+
+- id: solo-developer
+  title: Solo Developer
+  extends: [product-owner, architect, developer, tester, devops]
+  agent_kind: human
+  tool_categories: [vcs]
+  phases: [vision, requirements, architecture, development, testing, deployment, operations]
+  alphas: [Opportunity, Requirements, Software System, Work, Stakeholders, Way of Working, Team]
+EOF
+fi
+
 env_example="${target}/.env.example"
 if [ ! -f "$env_example" ]; then
   cat > "$env_example" <<'EOF'

--- a/tests/unit/bootstrap-role-extensions.bats
+++ b/tests/unit/bootstrap-role-extensions.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git rev-parse --show-toplevel)"
+  SCRIPT="$ROOT/scripts/bootstrap-target.sh"
+  TMP_DIR="$(mktemp -d)"
+  TARGET_DIR="$TMP_DIR/target"
+  mkdir -p "$TARGET_DIR"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+@test "bootstrap creates role-extensions.md in .claude/sdlc/" {
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  [ -f "$TARGET_DIR/.claude/sdlc/role-extensions.md" ]
+}
+
+@test "role-extensions.md has correct frontmatter type" {
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  grep -q '^type: target-role-mapping' "$TARGET_DIR/.claude/sdlc/role-extensions.md"
+}
+
+@test "role-extensions.md has frontmatter with name and project" {
+  run bash "$SCRIPT" "$TARGET_DIR" fail-if-exists
+  [ "$status" -eq 0 ]
+  grep -q '^name: role-extensions' "$TARGET_DIR/.claude/sdlc/role-extensions.md"
+  grep -q "^project: $(basename "$TARGET_DIR")" "$TARGET_DIR/.claude/sdlc/role-extensions.md"
+}
+
+@test "existing role-extensions.md not overwritten in fail-if-exists mode" {
+  mkdir -p "$TARGET_DIR/.claude/sdlc"
+  echo "preserved" >"$TARGET_DIR/.claude/sdlc/role-extensions.md"
+  rm -rf "$TARGET_DIR/.claude/sdlc"
+  mkdir -p "$TARGET_DIR/.claude/sdlc"
+  echo "preserved-content" >"$TARGET_DIR/.claude/sdlc/role-extensions.md"
+  run bash "$SCRIPT" "$TARGET_DIR" merge
+  [ "$status" -eq 0 ]
+  grep -q 'preserved-content' "$TARGET_DIR/.claude/sdlc/role-extensions.md"
+}


### PR DESCRIPTION
## Summary

Закрывает #57 (Gap-4, P1) из Wave 6 backlog. `bootstrap-target.sh` создаёт `<target>/.claude/sdlc/role-extensions.md` placeholder при `/sdlc-init`.

## Why

Wave 6 gt-validation выявила что bootstrap не создавал обязательный артефакт `role-extensions.md` (определён ADR-015 / `target-roles.meta.md`). Enterprise-targets требовали ручного создания после init.

## Tests

- Unit total: 100 → 104 кейсов.
- `tests/unit/bootstrap-role-extensions.bats` — 4 кейса (file exists / type frontmatter / name+project / merge-mode preserves).
- Все 104 unit + 47 integration GREEN.

## Test plan

- [x] `bats tests/unit/bootstrap-role-extensions.bats` — 4/4 GREEN
- [x] `bats tests/unit/` — 104/104 GREEN
- [x] `bats tests/integration/` — 47/47 GREEN
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [ ] CI зелёный
- [ ] После merge — release v0.8.0

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)