### PR TITLE
feat(wave-7): Gap-6 work-unit meta-templates per tracker (Jira/Linear/GitHub)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-10
+
+### Added
+
+- **Gap-6 (#58, P1)**: 3 tracker-flavored work-unit meta-templates (Jira, Linear, GitHub Issues). Каждый extends `work-product.meta.md`, содержит специфичные frontmatter-поля и секции для своего tracker'а.
+- `meta-templates/work-unit.jira.meta.md` — Epic/Story/Task/Sub-task, story_points, sprint, components/labels, epic-link, linked-issues.
+- `meta-templates/work-unit.linear.meta.md` — issue_id (ENG-123), project_id, cycle_id, priority (0-4), estimate (1/2/3/5/8), parent_issue, relations.
+- `meta-templates/work-unit.github.meta.md` — issue_number, milestone, labels, task-list AC, linked_pr, closes_issues. Pet-friendly default.
+- Поле `work_unit_template` в `meta-templates/plugin-config.meta.md` — выбор шаблона (`jira` / `linear` / `github`).
+- `tests/unit/work-unit-templates.bats` — 7 кейсов (existence / frontmatter / extends / config field / alphas).
+
+### Changed
+
+- README inventory: Meta-templates 16→19 (+3 work-unit-* templates); Unit tests 104→111 кейсов; +`work-unit-templates.bats` (7 кейсов).
+
+### Why
+
+Wave 6 gt-validation выявила что плагин не имеет templated work-unit format для разных issue-tracker категорий. Каждый tracker (Jira/Linear/GitHub) имеет специфичный набор полей и workflow. Без templates пользователь должен сам решать схему.
+
 ## [0.8.0] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
 - `launch-sdlc-state-rag.sh` — launcher MCP-сервера sdlc-state-rag с fallback PATH→nvm→standard locations→npx (v0.5.2).
 - `check-adr-paths.sh` — валидирует `adr_paths` в `plugin-config.md` целевого (Волна 6, v0.6.0).
 
-### Meta-templates (16)
+### Meta-templates (19)
 - `work-product.meta.md` — базовая схема рабочего продукта.
 - `phase-artifact.meta.md` — схема любого артефакта фазы.
 - `profile.meta.md` — схема SME-выбора целевого.
@@ -127,6 +127,9 @@
 - `sdlc-state-rag-contract.meta.md` — контракт MCP-сервера sdlc-state-rag (Волна 5, ADR-011).
 - `rag-config.meta.md` — схема `rag-config.md` целевого и worker'ов (Волна 5, ADR-012).
 - `webhooks.meta.md` — схема `webhooks.md` целевого для enterprise (Волна 5, ADR-014).
+- `work-unit.jira.meta.md` — схема work-unit для Jira-managed целевых (Волна 7, v0.9.0, Gap-6).
+- `work-unit.linear.meta.md` — схема work-unit для Linear-managed целевых (Волна 7, v0.9.0, Gap-6).
+- `work-unit.github.meta.md` — схема work-unit для GitHub Issues-managed целевых (Волна 7, v0.9.0, Gap-6).
 
 ### Catalogs (5)
 - `catalogs/alphas.md` — определения альф SDLC.
@@ -156,7 +159,7 @@
 
 Пирамида автотестов по фазе testing (уровень mid).
 
-- Unit (bats-core) — `tests/unit/` (14 файлов, 104 кейсa):
+- Unit (bats-core) — `tests/unit/` (15 файлов, 111 кейсов):
   - `validate-artifact.bats` — 7 кейсов на поведение валидатора.
   - `check-cross-refs.bats` — 6 кейсов на детектор осиротевших ссылок.
   - `enforce-no-comments.bats` — 13 кейсов (TypeScript whitelist Wave 5 + heredoc detection Wave 7).
@@ -171,6 +174,7 @@
   - `init-mcp-json.bats` — 5 кейсов на авто-создание/мердж `.mcp.json` в target (Волна 6, v0.6.0).
   - `plugin-config-adr-paths.bats` — 5 кейсов на валидацию `adr_paths` в plugin-config (Волна 6, v0.6.0).
   - `bootstrap-role-extensions.bats` — 4 кейса на создание `role-extensions.md` placeholder при /sdlc-init (Волна 7, v0.8.0).
+  - `work-unit-templates.bats` — 7 кейсов на 3 work-unit meta-templates (Jira/Linear/GitHub) (Волна 7, v0.9.0).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/meta-templates/plugin-config.meta.md
+++ b/meta-templates/plugin-config.meta.md
@@ -157,6 +157,18 @@ phase_enforcement:
 `SDLC_PHASE_ENFORCE=skip` — escape hatch для CI.
 Эфемерный override — через `/sdlc-autonomy --task hootl --duration <N>m` пишет `.claude/sdlc/autonomy.session.md`.
 
+### work_unit_template (Волна 7, опционально)
+
+Имя tracker-flavored шаблона work-unit для фазы requirements.
+
+```yaml
+work_unit_template: jira | linear | github
+```
+
+При `jira` skill `sdlc-requirements` использует `meta-templates/work-unit.jira.meta.md`.
+Аналогично `linear`, `github`. Default — `github` (pet-friendly).
+Поле выбирается на основе `tool-bindings.md` категории `issue-tracker`.
+
 ### adr_paths (Волна 6, опционально)
 
 Пути к каталогам ADR в целевом проекте.

--- a/meta-templates/work-unit.github.meta.md
+++ b/meta-templates/work-unit.github.meta.md
@@ -1,0 +1,85 @@
+---
+name: work-unit.github.meta
+type: meta-template
+scope: схема work-unit для GitHub Issues-managed целевых
+extends: work-product.meta.md
+location_in_target: .claude/sdlc/phases/requirements/<work-unit-slug>.md
+source: ADR-013, ADR-016; Wave 7 Gap-6
+tracker_category: issue-tracker
+tracker_tool: github
+---
+
+# Мета-шаблон work-unit (GitHub Issues-flavored)
+
+Используется когда `tool-bindings.md` указывает GitHub Issues как issue-tracker.
+Подходит pet-проектам и open-source.
+
+## Обязательный frontmatter
+
+```yaml
+---
+name: <issue-slug>
+type: work-unit
+phase: requirements
+project: <target-project>
+tracker: github
+repo: <owner/repo>
+issue_number: <int> или null если не создан
+milestone: <milestone-name> или null
+labels: [<label>, ...]
+sme_level: <pet|mid|enterprise>
+alphas: [Work, Requirements]
+role: <product-owner|developer>
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+```
+
+## Обязательные секции
+
+### 1. Title + Body
+
+GitHub style: title ≤72 символа, body в markdown.
+
+### 2. Acceptance Criteria
+
+Bullet-list checkboxes (`- [ ]` task list).
+
+### 3. Definition of Done
+
+Список технических критериев (тесты, документация, ревью).
+
+### 4. Labels (категоризация)
+
+Стандартные: `bug`, `enhancement`, `documentation`, `wave-N`, `pN`.
+
+### 5. Milestone
+
+Привязка к milestone (release или sprint).
+
+### 6. Связанные альфы
+
+`Work`, `Requirements`.
+
+## Поля специфичные для GitHub
+
+- `assignees` — список handle'ов.
+- `linked_pr` — номер PR при merge.
+- `closes_issues` — issues, которые закрываются этим work-unit'ом.
+
+## Правила
+
+- Создание через `sdlc-tool-router` → `mcp__github__create_issue`.
+- AskUserQuestion перед write (принцип 1).
+- `issue_number` записывается после успешного создания.
+
+## Валидация
+
+`validate-artifact.sh` + проверка `tracker: github`.
+
+## Pet-friendly особенность
+
+GitHub Issues — самый low-friction для pet-проектов:
+- Public repo → free issue tracking.
+- GitHub MCP — Wave 4 baseline integration.
+- Markdown-friendly.

--- a/meta-templates/work-unit.jira.meta.md
+++ b/meta-templates/work-unit.jira.meta.md
@@ -1,0 +1,77 @@
+---
+name: work-unit.jira.meta
+type: meta-template
+scope: схема work-unit для Jira-managed целевых
+extends: work-product.meta.md
+location_in_target: .claude/sdlc/phases/requirements/<work-unit-slug>.md
+source: ADR-013 (категории), ADR-016 (tool-router); Wave 7 Gap-6
+tracker_category: issue-tracker
+tracker_tool: jira
+---
+
+# Мета-шаблон work-unit (Jira-flavored)
+
+Используется когда `tool-bindings.md` указывает Jira как issue-tracker.
+Соответствует Jira issue types: Epic / Story / Task / Sub-task.
+
+## Обязательный frontmatter
+
+```yaml
+---
+name: <issue-slug>
+type: work-unit
+phase: requirements
+project: <target-project>
+tracker: jira
+issue_type: epic | story | task | sub-task
+issue_key: <PROJ-1234> или null если не создан
+parent_key: <PARENT-1234> для sub-task
+sme_level: <pet|mid|enterprise>
+alphas: [Work, Requirements]
+role: <product-manager|architect|developer>
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+```
+
+## Обязательные секции
+
+### 1. Заголовок и описание (Jira: Summary + Description)
+
+Краткое summary ≤80 символов; полное описание ≤200 слов.
+
+### 2. Acceptance Criteria
+
+Bullet-list проверяемых утверждений. Минимум 3.
+
+### 3. Story points (для story и task)
+
+Plan-poker оценка: 1, 2, 3, 5, 8, 13, 21.
+
+### 4. Sprint / Fix version
+
+Привязка к sprint cycle или milestone.
+
+### 5. Components / Labels
+
+Jira components и labels для классификации.
+
+### 6. Связанные альфы
+
+`Work` (initiated → under-control), `Requirements`.
+
+## Поля специфичные для Jira
+
+- `epic-link` — ссылка на parent epic.
+- `linked-issues` — blocks / is-blocked-by / relates-to.
+- `assignee` — slug человека (если приватность позволяет).
+
+## Правила
+
+- Создание Jira issue делегируется `sdlc-tool-router` (write через MCP).
+- Перед созданием — `AskUserQuestion` (принцип 1).
+- `issue_key` записывается ПОСЛЕ создания через MCP.
+
+## Валидация
+
+`validate-artifact.sh` + специфичная проверка `tracker: jira` ↔ `tool-bindings.md`.

--- a/meta-templates/work-unit.linear.meta.md
+++ b/meta-templates/work-unit.linear.meta.md
@@ -1,0 +1,79 @@
+---
+name: work-unit.linear.meta
+type: meta-template
+scope: схема work-unit для Linear-managed целевых
+extends: work-product.meta.md
+location_in_target: .claude/sdlc/phases/requirements/<work-unit-slug>.md
+source: ADR-013, ADR-016; Wave 7 Gap-6
+tracker_category: issue-tracker
+tracker_tool: linear
+---
+
+# Мета-шаблон work-unit (Linear-flavored)
+
+Используется когда `tool-bindings.md` указывает Linear как issue-tracker.
+
+## Обязательный frontmatter
+
+```yaml
+---
+name: <issue-slug>
+type: work-unit
+phase: requirements
+project: <target-project>
+tracker: linear
+issue_id: <ENG-123> или null если не создан
+team_key: <ENG>
+project_id: <linear-project-uuid> или null
+cycle_id: <linear-cycle-uuid> или null
+sme_level: <pet|mid|enterprise>
+alphas: [Work, Requirements]
+role: <product-manager|architect|developer>
+priority: 0 | 1 | 2 | 3 | 4
+estimate: 1 | 2 | 3 | 5 | 8
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+```
+
+## Обязательные секции
+
+### 1. Title + Description
+
+Linear style: title ≤80 символов, description в markdown.
+
+### 2. Acceptance Criteria
+
+Bullet-list. Минимум 3.
+
+### 3. Estimate (T-shirt или Fibonacci)
+
+`estimate` поле в frontmatter (Fibonacci 1/2/3/5/8).
+
+### 4. Priority
+
+`priority`: 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low.
+
+### 5. Project / Cycle
+
+Привязка к Linear project и текущему cycle.
+
+### 6. Связанные альфы
+
+`Work`, `Requirements`.
+
+## Поля специфичные для Linear
+
+- `parent_issue` — для sub-issues.
+- `relations` — blocks / blocked-by / related-to (Linear native).
+- `labels` — Linear labels.
+
+## Правила
+
+- Создание Linear issue через `sdlc-tool-router` (Linear MCP).
+- AskUserQuestion перед write (принцип 1).
+- `issue_id` записывается после успешного создания.
+
+## Валидация
+
+`validate-artifact.sh` + проверка `tracker: linear`.

--- a/scripts/check-readme-inventory.sh
+++ b/scripts/check-readme-inventory.sh
@@ -46,7 +46,7 @@ skills_readme = set(re.findall(r"`(sdlc-[a-z-]+)`", find_section("Skills")))
 commands_readme = set(re.findall(r"/(sdlc-[a-z-]+)", find_section("Commands")))
 agents_readme = set(re.findall(r"`(sdlc-[a-z-]+)`", find_section("Agents")))
 scripts_readme = set(re.findall(r"`([a-z][a-z0-9-]*\.sh)`", find_section("Scripts")))
-meta_readme = set(re.findall(r"`([a-z][a-z0-9-]*\.meta\.md)`", find_section("Meta-templates")))
+meta_readme = set(re.findall(r"`([a-z][a-z0-9.\-]*\.meta\.md)`", find_section("Meta-templates")))
 
 errors = 0
 

--- a/tests/unit/work-unit-templates.bats
+++ b/tests/unit/work-unit-templates.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git rev-parse --show-toplevel)"
+  META_DIR="$ROOT/meta-templates"
+}
+
+@test "work-unit.jira.meta.md exists" {
+  [ -f "$META_DIR/work-unit.jira.meta.md" ]
+}
+
+@test "work-unit.linear.meta.md exists" {
+  [ -f "$META_DIR/work-unit.linear.meta.md" ]
+}
+
+@test "work-unit.github.meta.md exists" {
+  [ -f "$META_DIR/work-unit.github.meta.md" ]
+}
+
+@test "all 3 templates have correct frontmatter" {
+  for tracker in jira linear github; do
+    f="$META_DIR/work-unit.$tracker.meta.md"
+    grep -q "^name: work-unit.$tracker.meta" "$f"
+    grep -q "^type: meta-template" "$f"
+    grep -q "^tracker_category: issue-tracker" "$f"
+    grep -q "^tracker_tool: $tracker" "$f"
+  done
+}
+
+@test "all 3 templates extend work-product.meta.md" {
+  for tracker in jira linear github; do
+    grep -q "^extends: work-product.meta.md" "$META_DIR/work-unit.$tracker.meta.md"
+  done
+}
+
+@test "plugin-config.meta.md declares work_unit_template field" {
+  grep -q "work_unit_template" "$META_DIR/plugin-config.meta.md"
+}
+
+@test "all 3 templates declare alphas Work and Requirements" {
+  for tracker in jira linear github; do
+    grep -qE "alphas:.*Work" "$META_DIR/work-unit.$tracker.meta.md"
+    grep -qE "alphas:.*Requirements" "$META_DIR/work-unit.$tracker.meta.md"
+  done
+}


### PR DESCRIPTION
## Summary

Закрывает #58 (Gap-6, P1) из Wave 6 backlog. 3 tracker-flavored work-unit meta-templates + поле `work_unit_template` в plugin-config.

## Why

Wave 6 gt-validation: каждый issue-tracker (Jira/Linear/GitHub) имеет специфичные поля и workflow. Плагин не имел шаблона, специфичного для tracker'а.

## Changes

- `meta-templates/work-unit.jira.meta.md` — Epic/Story/Task/Sub-task pattern.
- `meta-templates/work-unit.linear.meta.md` — Linear issue pattern.
- `meta-templates/work-unit.github.meta.md` — GitHub Issues pattern (pet-friendly default).
- `meta-templates/plugin-config.meta.md` — поле `work_unit_template`.
- `scripts/check-readme-inventory.sh` — regex принимает точки в именах meta-templates.
- `tests/unit/work-unit-templates.bats` — 7 кейсов.

## Tests

- Unit total: 104 → 111 кейсов.
- Все 111 unit + 47 integration GREEN.
- check-readme-inventory: OK.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)