### PR TITLE
feat(wave-7): Gap-3 P0 external-systems references для enterprise-MCP

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-10
+
+### Added
+
+- **Gap-3 (#54, P0)**: 5 reference-документов в `meta-templates/external-systems/` для популярных enterprise-MCP-серверов:
+  - `issue-tracker.jira.md` — Atlassian Rovo + sooperset/mcp-atlassian.
+  - `knowledge-base.confluence.md` — единый Atlassian-сервер.
+  - `vcs.bitbucket.md` — Atlassian Rovo + community Bitbucket MCP.
+  - `observability.grafana.md` — official mcp-grafana (Loki/Prometheus/Tempo).
+  - `cd-platform.argocd.md` — community argocd-mcp.
+- Каждый файл: install-команды, env-vars, capability mapping, `tool-bindings.md` пример.
+- `catalogs/method-tool-matrix.md` — раздел 11a со ссылками на references.
+- `tests/unit/external-systems-references.bats` — 10 кейсов (existence × 5, frontmatter, sections, matrix-references).
+
+### Changed
+
+- README inventory: Unit tests 111→121 кейсов; новый подраздел `External-system references` в Meta-templates.
+
+### Why
+
+Wave 6 gt-validation выявила что enterprise-targets не имеют готовых рекомендаций для подключения MCP-серверов к стеку (Jira/Confluence/Bitbucket/Grafana/ArgoCD). Без references пользователь должен изобретать конфигурацию с нуля. Этот release завершает Wave 7 (Gap-0/2/3/4/6 закрыты).
+
 ## [0.9.0] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@
 - `work-unit.linear.meta.md` — схема work-unit для Linear-managed целевых (Волна 7, v0.9.0, Gap-6).
 - `work-unit.github.meta.md` — схема work-unit для GitHub Issues-managed целевых (Волна 7, v0.9.0, Gap-6).
 
+#### External-system references (`meta-templates/external-systems/`, Волна 7 v0.10.0)
+- `issue-tracker.jira.md` — Atlassian Rovo / sooperset/mcp-atlassian.
+- `knowledge-base.confluence.md` — единый Atlassian-сервер для Confluence.
+- `vcs.bitbucket.md` — Atlassian Rovo / community Bitbucket MCP.
+- `observability.grafana.md` — official mcp-grafana (Loki/Prometheus/Tempo).
+- `cd-platform.argocd.md` — community argocd-mcp.
+
 ### Catalogs (5)
 - `catalogs/alphas.md` — определения альф SDLC.
 - `catalogs/disciplines.md` — дисциплины, закреплённые за фазами.
@@ -159,7 +166,7 @@
 
 Пирамида автотестов по фазе testing (уровень mid).
 
-- Unit (bats-core) — `tests/unit/` (15 файлов, 111 кейсов):
+- Unit (bats-core) — `tests/unit/` (16 файлов, 121 кейс):
   - `validate-artifact.bats` — 7 кейсов на поведение валидатора.
   - `check-cross-refs.bats` — 6 кейсов на детектор осиротевших ссылок.
   - `enforce-no-comments.bats` — 13 кейсов (TypeScript whitelist Wave 5 + heredoc detection Wave 7).
@@ -175,6 +182,7 @@
   - `plugin-config-adr-paths.bats` — 5 кейсов на валидацию `adr_paths` в plugin-config (Волна 6, v0.6.0).
   - `bootstrap-role-extensions.bats` — 4 кейса на создание `role-extensions.md` placeholder при /sdlc-init (Волна 7, v0.8.0).
   - `work-unit-templates.bats` — 7 кейсов на 3 work-unit meta-templates (Jira/Linear/GitHub) (Волна 7, v0.9.0).
+  - `external-systems-references.bats` — 10 кейсов на 5 reference MCP-серверов (Волна 7, v0.10.0).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/catalogs/method-tool-matrix.md
+++ b/catalogs/method-tool-matrix.md
@@ -113,6 +113,20 @@ Skill `sdlc-method-engineering` объединяет матрицу плагин
 | mid | Автоматизированный конвейер с несколькими средами и blue-green | GitHub Actions deploy job • Octopus Deploy • Spinnaker |
 | enterprise | Декларативная доставка с прогрессивным выкатом и feature-флагами | ArgoCD • Flux • Harness Progressive Delivery |
 
+## 11a. External-system references (Wave 7, v0.10.0)
+
+Готовые reference-документы по подключению MCP-серверов для популярных enterprise-инструментов. Каждый файл содержит install-команды, env-vars, capability mapping и привязку к категории из `tool-categories.md`.
+
+| Категория | Reference |
+|---|---|
+| issue-tracker | [external-systems/issue-tracker.jira.md](../meta-templates/external-systems/issue-tracker.jira.md) — Atlassian Rovo / sooperset/mcp-atlassian |
+| knowledge-base | [external-systems/knowledge-base.confluence.md](../meta-templates/external-systems/knowledge-base.confluence.md) — Atlassian Rovo / sooperset |
+| vcs | [external-systems/vcs.bitbucket.md](../meta-templates/external-systems/vcs.bitbucket.md) — Atlassian Rovo / community Bitbucket MCP |
+| observability | [external-systems/observability.grafana.md](../meta-templates/external-systems/observability.grafana.md) — official mcp-grafana |
+| cd-platform | [external-systems/cd-platform.argocd.md](../meta-templates/external-systems/cd-platform.argocd.md) — community argocd-mcp |
+
+Skill `sdlc-integrations` ссылается на эти файлы при опросе пользователя. `sdlc-tool-router` использует capability mappings для маршрутизации.
+
 ## 12. Embedders для RAG (Wave 5)
 
 | Уровень | Метод (абстрактно) | Примеры инструментов |

--- a/meta-templates/external-systems/cd-platform.argocd.md
+++ b/meta-templates/external-systems/cd-platform.argocd.md
@@ -1,0 +1,92 @@
+---
+name: cd-platform.argocd
+type: external-system-reference
+category: cd-platform
+tool: argocd
+mcp_options:
+  - name: argocd-mcp
+    package: 'argoproj-labs/argocd-mcp'
+    auth: api_token
+    notes: Community ArgoCD MCP, GitOps-native
+env_vars: [ARGOCD_SERVER, ARGOCD_AUTH_TOKEN]
+capabilities: [app.list, app.sync, app.rollback, env.list, deploy.history]
+source: ADR-013, ADR-016, Wave 7 Gap-3
+---
+
+# Reference: ArgoCD как cd-platform
+
+Подключение ArgoCD как MCP-сервера для категории `cd-platform`. GitOps-native CD для Kubernetes.
+
+## Установка
+
+### argocd-mcp (community)
+
+```bash
+npm install -g argocd-mcp-server
+```
+
+Или сборка из исходников:
+
+```bash
+git clone https://github.com/argoproj-labs/argocd-mcp
+cd argocd-mcp && go build
+```
+
+В `<target>/.mcp.json`:
+
+```json
+"argocd": {
+  "type": "stdio",
+  "command": "argocd-mcp",
+  "args": []
+}
+```
+
+## Env переменные
+
+```bash
+ARGOCD_SERVER=argocd.your-org.com:443
+ARGOCD_AUTH_TOKEN=<account-jwt-token>
+```
+
+JWT token получается через ArgoCD CLI:
+
+```bash
+argocd account generate-token --account <bot-account>
+```
+
+## Capabilities mapping
+
+| Capability | ArgoCD действие |
+|---|---|
+| app.list | List Applications в proj/ns |
+| app.sync | Trigger sync (manual или auto) |
+| app.rollback | Rollback to previous Git revision |
+| env.list | Cluster + namespace mappings |
+| deploy.history | Sync history per app |
+
+## Привязка в `tool-bindings.md`
+
+```yaml
+- category: cd-platform
+  mcp_server: argocd
+  env_keys: [ARGOCD_SERVER, ARGOCD_AUTH_TOKEN]
+  capabilities: [app.list, app.sync, deploy.history]
+```
+
+## Use в плагине
+
+- Фаза deployment → trigger sync через `sdlc-tool-router` (write требует `AskUserQuestion` per принцип 1).
+- Фаза operations → проверка состояния deployments.
+- Альфа `Software System` продвигается в `Operational` после успешного sync.
+
+## Безопасность
+
+- Bot account с минимальным RBAC (read + sync, без admin).
+- Token rotation через ArgoCD CLI.
+- `.env` обязательно gitignored (принцип 10).
+
+## Связь с другими категориями
+
+- `vcs` (Bitbucket/GitHub) — source-of-truth для манифестов.
+- `observability` (Grafana) — health-check после sync.

--- a/meta-templates/external-systems/issue-tracker.jira.md
+++ b/meta-templates/external-systems/issue-tracker.jira.md
@@ -1,0 +1,100 @@
+---
+name: issue-tracker.jira
+type: external-system-reference
+category: issue-tracker
+tool: jira
+mcp_options:
+  - name: atlassian-rovo
+    package: '@atlassian/mcp-rovo'
+    auth: oauth2
+    notes: Official Atlassian (GA Feb 2026), bundled with Cloud Premium
+  - name: sooperset-mcp-atlassian
+    package: 'sooperset/mcp-atlassian'
+    auth: api_token
+    notes: Community, 72+ tools, supports both Jira+Confluence
+env_vars: [JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN]
+capabilities: [issue.create, issue.update, issue.search, comment.add, label.set, status.set]
+source: ADR-013, ADR-016, Wave 7 Gap-3
+---
+
+# Reference: Jira как issue-tracker
+
+Подключение Jira как MCP-сервера для категории `issue-tracker`.
+
+## Альтернативы (выбирается пользователем)
+
+### Atlassian Rovo MCP (official)
+
+- Package: `@atlassian/mcp-rovo` (или через Atlassian Cloud admin).
+- Auth: OAuth2 через Atlassian admin console.
+- Bundled с Atlassian Cloud Premium ($10.50+/user/mo).
+- Pros: official, deep integration с Jira+Confluence+Bitbucket.
+- Cons: requires Atlassian Cloud Premium subscription.
+
+### sooperset/mcp-atlassian (community)
+
+- Package: `sooperset/mcp-atlassian` (Python).
+- Auth: API token (Atlassian → My Account → API tokens).
+- 72+ tools для Jira+Confluence (combined).
+- Pros: free, self-hosted, broad coverage.
+- Cons: community-maintained, varies by version.
+
+## Установка
+
+### Atlassian Rovo
+
+1. Включить Rovo в Atlassian admin console.
+2. Получить OAuth credentials.
+3. В `<target>/.mcp.json` добавить:
+   ```json
+   "jira-rovo": {
+     "type": "stdio",
+     "command": "npx",
+     "args": ["-y", "@atlassian/mcp-rovo"]
+   }
+   ```
+
+### sooperset/mcp-atlassian
+
+1. Установить Python 3.10+.
+2. `pip install mcp-atlassian` или Docker pull.
+3. В `<target>/.mcp.json`:
+   ```json
+   "atlassian": {
+     "type": "stdio",
+     "command": "uvx",
+     "args": ["mcp-atlassian"]
+   }
+   ```
+
+## Env переменные (в `<target>/.env`)
+
+```bash
+JIRA_URL=https://your-org.atlassian.net
+JIRA_EMAIL=your-email@example.com
+JIRA_API_TOKEN=<token-from-atlassian-id>
+```
+
+`<target>/.gitignore` обязательно содержит `.env` (принцип 10).
+
+## Проверка подключения
+
+```bash
+claude mcp list | grep -E 'jira|atlassian'
+```
+
+Ожидается `✓ Connected`.
+
+## Привязка в `tool-bindings.md` целевого
+
+```yaml
+- category: issue-tracker
+  mcp_server: atlassian
+  env_keys: [JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN]
+  capabilities: [issue.create, issue.update, issue.search]
+```
+
+## Связь с work-unit template
+
+Для Jira-managed targets — `work_unit_template: jira` в `plugin-config.md`.
+Использует `meta-templates/work-unit.jira.meta.md` (Wave 7, v0.9.0).

--- a/meta-templates/external-systems/knowledge-base.confluence.md
+++ b/meta-templates/external-systems/knowledge-base.confluence.md
@@ -1,0 +1,76 @@
+---
+name: knowledge-base.confluence
+type: external-system-reference
+category: knowledge-base
+tool: confluence
+mcp_options:
+  - name: atlassian-rovo
+    package: '@atlassian/mcp-rovo'
+    auth: oauth2
+    notes: Official, bundled с Cloud Premium
+  - name: sooperset-mcp-atlassian
+    package: 'sooperset/mcp-atlassian'
+    auth: api_token
+    notes: Community, единый сервер для Jira+Confluence
+env_vars: [CONFLUENCE_URL, CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN]
+capabilities: [page.create, page.update, page.search, page.read, attachment.upload]
+source: ADR-013, ADR-016, Wave 7 Gap-3
+---
+
+# Reference: Confluence как knowledge-base
+
+Подключение Confluence как MCP-сервера для категории `knowledge-base`.
+
+## Установка
+
+### Atlassian Rovo (recommended если Atlassian Cloud Premium)
+
+См. `issue-tracker.jira.md` — единый Rovo-сервер покрывает Jira + Confluence + Bitbucket.
+
+### sooperset/mcp-atlassian
+
+Тот же сервер, что и для Jira:
+
+```bash
+pip install mcp-atlassian
+```
+
+В `<target>/.mcp.json`:
+
+```json
+"atlassian": {
+  "type": "stdio",
+  "command": "uvx",
+  "args": ["mcp-atlassian"]
+}
+```
+
+## Env переменные
+
+Если используется один Atlassian Cloud аккаунт, переменные те же что для Jira (см. `issue-tracker.jira.md`). Иначе:
+
+```bash
+CONFLUENCE_URL=https://your-org.atlassian.net/wiki
+CONFLUENCE_EMAIL=your-email@example.com
+CONFLUENCE_API_TOKEN=<atlassian-api-token>
+```
+
+## Привязка в `tool-bindings.md`
+
+```yaml
+- category: knowledge-base
+  mcp_server: atlassian
+  env_keys: [CONFLUENCE_URL, CONFLUENCE_EMAIL, CONFLUENCE_API_TOKEN]
+  capabilities: [page.create, page.update, page.search, page.read]
+```
+
+## Use в плагине
+
+`sdlc-context-aggregator` (категория knowledge-base) опрашивает Confluence для:
+- Architecture-документов на фазе architecture.
+- Runbooks на фазе operations.
+- Спецификаций требований на фазе requirements.
+
+## Связь с альфами
+
+`Requirements`, `Way of Working`.

--- a/meta-templates/external-systems/observability.grafana.md
+++ b/meta-templates/external-systems/observability.grafana.md
@@ -1,0 +1,84 @@
+---
+name: observability.grafana
+type: external-system-reference
+category: observability
+tool: grafana
+mcp_options:
+  - name: mcp-grafana
+    package: 'grafana/mcp-grafana'
+    auth: api_key
+    notes: Official Grafana Labs, supports Loki/Prometheus/Tempo/Alerting
+env_vars: [GRAFANA_URL, GRAFANA_API_KEY]
+capabilities: [metric.query, log.search, alert.list, trace.read, dashboard.read]
+source: ADR-013, ADR-016, Wave 7 Gap-3
+---
+
+# Reference: Grafana как observability
+
+Подключение Grafana как MCP-сервера для категории `observability`. Покрывает Prometheus (metrics), Loki (logs), Tempo (traces), Grafana Alerting.
+
+## Установка
+
+### mcp-grafana (official Grafana Labs)
+
+```bash
+git clone https://github.com/grafana/mcp-grafana
+cd mcp-grafana
+go build
+```
+
+Или через Docker:
+
+```bash
+docker pull grafana/mcp-grafana:latest
+```
+
+В `<target>/.mcp.json`:
+
+```json
+"grafana": {
+  "type": "stdio",
+  "command": "mcp-grafana",
+  "args": []
+}
+```
+
+## Env переменные
+
+```bash
+GRAFANA_URL=https://grafana.your-org.com
+GRAFANA_API_KEY=<service-account-token>
+```
+
+API key создаётся в Grafana Admin → Service Accounts → Token.
+
+## Capabilities mapping
+
+| Capability | Grafana механизм |
+|---|---|
+| metric.query | PromQL via Prometheus datasource |
+| log.search | LogQL via Loki datasource |
+| alert.list | Grafana Alerting rules + active alerts |
+| trace.read | TraceQL via Tempo datasource |
+| dashboard.read | Grafana Dashboards API |
+
+## Привязка в `tool-bindings.md`
+
+```yaml
+- category: observability
+  mcp_server: grafana
+  env_keys: [GRAFANA_URL, GRAFANA_API_KEY]
+  capabilities: [metric.query, log.search, alert.list, dashboard.read]
+```
+
+## Use в плагине
+
+- Фаза operations → инцидент-мониторинг через `sdlc-context-aggregator`.
+- Фаза deployment → проверка здоровья после rollout.
+- Альфа `Software System` → продвижение в `In Use` подтверждается через uptime metrics.
+
+## Self-hosted vs Grafana Cloud
+
+- Self-hosted: API key через ваш Grafana instance.
+- Grafana Cloud: API key через cloud admin console.
+- Stack Tokens (Cloud) поддерживают per-stack scoping.

--- a/meta-templates/external-systems/vcs.bitbucket.md
+++ b/meta-templates/external-systems/vcs.bitbucket.md
@@ -1,0 +1,81 @@
+---
+name: vcs.bitbucket
+type: external-system-reference
+category: vcs
+tool: bitbucket
+mcp_options:
+  - name: atlassian-rovo
+    package: '@atlassian/mcp-rovo'
+    auth: oauth2
+    notes: Official, единый сервер с Jira+Confluence+Bitbucket
+  - name: bitbucket-mcp-community
+    package: 'bitbucket-mcp-server'
+    auth: app_password
+    notes: Community standalone Bitbucket MCP
+env_vars: [BITBUCKET_WORKSPACE, BITBUCKET_USERNAME, BITBUCKET_APP_PASSWORD]
+capabilities: [pr.create, pr.review, pr.merge, branch.create, commit.read, tag.create, file.read]
+source: ADR-013, ADR-016, Wave 7 Gap-3
+---
+
+# Reference: Bitbucket как vcs
+
+Подключение Bitbucket Cloud как MCP-сервера для категории `vcs`.
+
+## Установка
+
+### Atlassian Rovo
+
+См. `issue-tracker.jira.md` — единый Rovo-сервер.
+
+### Community Bitbucket MCP
+
+```bash
+npm install -g bitbucket-mcp-server
+```
+
+В `<target>/.mcp.json`:
+
+```json
+"bitbucket": {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "bitbucket-mcp-server"]
+}
+```
+
+## Env переменные
+
+Bitbucket app passwords создаются в Personal Settings → App passwords:
+
+```bash
+BITBUCKET_WORKSPACE=your-org
+BITBUCKET_USERNAME=your-username
+BITBUCKET_APP_PASSWORD=<app-password>
+```
+
+App password требует scopes: `repository:write`, `pullrequest:write`.
+
+## Установка для team (Bitbucket Cloud)
+
+1. Admin создаёт API token / app passwords.
+2. Каждый разработчик ставит свои credentials в локальный `.env`.
+3. CI/CD pipelines используют bot account credentials.
+
+## Привязка в `tool-bindings.md`
+
+```yaml
+- category: vcs
+  mcp_server: bitbucket
+  env_keys: [BITBUCKET_WORKSPACE, BITBUCKET_USERNAME, BITBUCKET_APP_PASSWORD]
+  capabilities: [pr.create, pr.review, pr.merge, branch.create, commit.read]
+```
+
+## Use в плагине
+
+- Фаза development → создание feature branches, PR review.
+- Фаза deployment → release tags.
+- `sdlc-context-aggregator` опрашивает для diff'ов и commit history.
+
+## Связь с альфой
+
+`Software System` — отслеживается через теги релизов.

--- a/tests/unit/external-systems-references.bats
+++ b/tests/unit/external-systems-references.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git rev-parse --show-toplevel)"
+  EXT_DIR="$ROOT/meta-templates/external-systems"
+}
+
+@test "external-systems directory exists" {
+  [ -d "$EXT_DIR" ]
+}
+
+@test "issue-tracker.jira.md reference exists" {
+  [ -f "$EXT_DIR/issue-tracker.jira.md" ]
+}
+
+@test "knowledge-base.confluence.md reference exists" {
+  [ -f "$EXT_DIR/knowledge-base.confluence.md" ]
+}
+
+@test "vcs.bitbucket.md reference exists" {
+  [ -f "$EXT_DIR/vcs.bitbucket.md" ]
+}
+
+@test "observability.grafana.md reference exists" {
+  [ -f "$EXT_DIR/observability.grafana.md" ]
+}
+
+@test "cd-platform.argocd.md reference exists" {
+  [ -f "$EXT_DIR/cd-platform.argocd.md" ]
+}
+
+@test "all references have correct frontmatter type" {
+  for f in "$EXT_DIR"/*.md; do
+    grep -q '^type: external-system-reference' "$f" || {
+      echo "missing frontmatter type in: $f"
+      false
+    }
+  done
+}
+
+@test "all references declare category and tool" {
+  for f in "$EXT_DIR"/*.md; do
+    grep -q '^category:' "$f"
+    grep -q '^tool:' "$f"
+  done
+}
+
+@test "all references declare install_command and env_vars sections" {
+  for f in "$EXT_DIR"/*.md; do
+    grep -qE '^## (Установка|Install)' "$f"
+    grep -qE '^## (Env|Переменные)' "$f"
+  done
+}
+
+@test "method-tool-matrix references at least 3 external-systems files" {
+  count=$(grep -cE 'external-systems/[a-z][a-z0-9.\-]+\.md' "$ROOT/catalogs/method-tool-matrix.md" || true)
+  [ "$count" -ge 3 ]
+}


### PR DESCRIPTION
## Summary

Закрывает #54 (Gap-3, **P0**) — последний из Wave 6 backlog. **Wave 7 финализирован** (5 issues закрыты).

5 reference-документов в `meta-templates/external-systems/` для популярных enterprise-MCP-серверов: Jira / Confluence / Bitbucket / Grafana / ArgoCD.

## Why

Wave 6 gt-validation: enterprise-targets не имели готовых рекомендаций для подключения MCP-серверов к стеку. Без references пользователь должен изобретать конфигурацию с нуля.

## Changes

- `meta-templates/external-systems/issue-tracker.jira.md`
- `meta-templates/external-systems/knowledge-base.confluence.md`
- `meta-templates/external-systems/vcs.bitbucket.md`
- `meta-templates/external-systems/observability.grafana.md`
- `meta-templates/external-systems/cd-platform.argocd.md`
- `catalogs/method-tool-matrix.md` — раздел 11a с таблицей ссылок.
- `tests/unit/external-systems-references.bats` — 10 кейсов.
- `README.md` — новый подраздел в Meta-templates.
- `CHANGELOG.md` — секция [0.10.0].

## Tests

- Unit total: 111 → 121 кейс.
- Все 121 unit + 47 integration GREEN.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)