### PR TITLE
release(v0.10.1): docs-only patch для Wave 7 closure drift cleanup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -4,8 +4,8 @@ type: sdlc-profile
 project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
-active_phase: development
-active_phase_set_at: 2026-05-10T19:49:21Z
+active_phase: deployment
+active_phase_set_at: 2026-05-10T20:06:57Z
 ---
 
 # SME-профиль проекта
@@ -52,3 +52,4 @@ active_phase_set_at: 2026-05-10T19:49:21Z
 - 2026-05-10 — Wave 7 v0.7.0..v0.10.0: closed issues #54-#58 (1 P0 + 4 P1); 4 PR merged (#62-#65).
 - 2026-05-10 — фаза development re-активирована для docs-PR drift cleanup (Wave 7 closure).
 - 2026-05-10 — `sdlc-integrations` skill (Wave 4) фиксируется как **out-of-band** cross-cutting; не отдельная фаза в SME-таблице.
+- 2026-05-10 — фаза deployment активирована для release v0.10.1 patch (PR #66 merged).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-05-10
+
+### Changed
+
+- **Wave 7 closure docs drift cleanup** (audit `/sdlc-audit` warn 0/6/3 → fixes):
+  - `README.md` counters: версия v0.3.1 → **v0.10.0** (uplifted после Wave 6-7); «23 принципа» → **«22+4a+19a, 24 секции»**; bench-hooks **8 → 9**; Meta-templates **19 → 24** (19 top + 5 external-systems).
+  - `memom.md` +2 записи: **2026-05-10 Wave 6-7 cleanup** (агрегированная) + **принцип 13 ratify в Wave 7 audit** (essence-alpha-mcp полностью удалён).
+  - `.claude/sdlc/phases/architecture/architecture.md`: §5а с таблицей ADR-010..016 (Wave 4-5 snapshot); `essence_validate_consistency` → `state_validate_consistency`; npm pkg name `@ypolosov/sdlc-state-rag`.
+  - `.claude/sdlc/profile.md`: +6 history-записей Wave 4-7; `sdlc-integrations` skill помечен как out-of-band cross-cutting (не SDLC-фаза).
+  - `.claude/sdlc/alphas.md`: Software System evidence обновлён на `CHANGELOG.md#0.10.0`; +3 строки журнала (decisions через MCP).
+  - `.claude/sdlc/audit.md`: Wave 7 audit результаты (warn 0/6/3) зафиксированы.
+
+### Reorganized
+
+- `release-notes-v*.md` (12 файлов v0.3.0..v0.10.0) перенесены из root в `docs/release-notes/`.
+- `.gitignore`: паттерн `release-notes-v*.md` → `/release-notes-v*.md` (root only); committed-копии в `docs/release-notes/` теперь tracked.
+
+### Why
+
+После быстрой череды релизов v0.6.0..v0.10.0 (Wave 6-7) накопился drift документации: счётчики README устарели, memom не отражал Wave 6-7, architecture.md ссылался на deprecated `essence-alpha-mcp`. Patch-релиз без поведенческих изменений; только docs sync. PR #66 merged 2026-05-10 после `/sdlc-audit` (commit 101012e в main).
+
+### Plugin tools used (принцип 12 dogfooding)
+
+- skill `/sdlc-phase development` + `/sdlc-phase deployment` активированы методологически.
+- `AskUserQuestion` ×2 (принцип 1) — scope-выбор ДО правок и ДО release.
+- `mcp__sdlc-state-rag__decisions_record` ×4 (id 1-4: phase activation, software-system evidence, way-of-working evidence, deployment scope).
+- `scripts/check-readme-inventory.sh` + `check-memom-consistency.sh` — green pre-merge.
+- Принципы: 1, 13, 15, 16, 22.
+
 ## [0.10.0] — 2026-05-10
 
 ### Added

--- a/docs/release-notes/release-notes-v0.10.1.md
+++ b/docs/release-notes/release-notes-v0.10.1.md
@@ -1,0 +1,78 @@
+# Release v0.10.1 — Wave 7 closure docs drift cleanup
+
+**Type:** patch (docs-only).
+**Date:** 2026-05-10.
+**Closes:** Wave 7 closure (PR #66 merged).
+**Audit baseline:** `/sdlc-audit` warn 0/6/3 → expected pass after this release.
+
+## Что изменилось
+
+Patch-релиз без поведенческих изменений. Только синхронизация документации после быстрой череды релизов v0.6.0..v0.10.0 (Wave 6-7).
+
+### README counters (W-3)
+
+- Версия: v0.3.1 → **v0.10.0** (uplifted после Wave 6-7).
+- Принципы: «23 принципа» → **«22 принципа + 4a + 19a, 24 секции»** (разрешено противоречие).
+- Bench-hooks: **8 → 9** (после Wave 5 enforce-sdlc-phase).
+- Meta-templates: **19 → 24** (19 top + 5 external-systems в subdir).
+- Финальная фраза «Как читать плагин»: «17 принципов + 4a» → актуальная формулировка.
+
+### memom.md (W-2)
+
+Добавлены 2 записи:
+
+- **2026-05-10 — Wave 6-7 cleanup**: агрегированная запись закрытия 5 issues (#54-#58), 4 PR (#62-#65), 5 релизов (v0.6.0..v0.10.0). Уточнения принципов 14, 18, 22, 4a без формальных правок.
+- **2026-05-10 — принцип 13 ratify**: подтверждение что `essence-alpha-mcp` полностью удалён в Wave 5; ADR-009 Deprecated; все ссылки на `essence_validate_consistency` заменены на `state_validate_consistency`.
+
+### architecture.md (W-1, W-4)
+
+- §5а с таблицей ADR-010..016 (Wave 4-5 snapshot).
+- Строки 88-89: `essence_validate_consistency` → `state_validate_consistency`; npm pkg name `@ypolosov/sdlc-state-rag`.
+
+### profile.md (W-5)
+
+- +6 history-записей: Wave 4 (PR-A..G), Wave 5 v0.5.0/v0.5.1..v0.5.4, Wave 6 v0.6.0, Wave 7 v0.7.0..v0.10.0, фаза-активации.
+- `sdlc-integrations` skill помечен как **out-of-band** cross-cutting (не SDLC-фаза в SME-таблице).
+
+### alphas.md (W-6)
+
+- Software System evidence: `CHANGELOG.md#0.3.0` → **`CHANGELOG.md#0.10.0`**; date 2026-05-02 → 2026-05-10.
+- +3 строки журнала: software-system evidence refresh; way-of-working evidence refresh с bench-hooks 9.
+- Зафиксировано через `mcp__sdlc-state-rag__decisions_record` ×3 (id 1, 2, 3).
+
+### release-notes layout (N-2)
+
+- 12 файлов `release-notes-v*.md` (v0.3.0..v0.10.0) перенесены из root в `docs/release-notes/`.
+- `.gitignore`: паттерн `release-notes-v*.md` → `/release-notes-v*.md` (root only).
+- Committed-копии теперь tracked в git; root остаётся для temp-файлов `gh release create --notes-file`.
+
+## Plugin tools used (принцип 12 dogfooding)
+
+| Tool | Назначение |
+|---|---|
+| skill `/sdlc-phase development` | Активация фазы для drift cleanup |
+| skill `/sdlc-phase deployment` | Активация фазы для release |
+| `AskUserQuestion` ×2 | Принцип 1 опрос ДО правок и ДО release |
+| `mcp__sdlc-state-rag__state_get_alpha` ×2 | Чтение Work, Software System |
+| `mcp__sdlc-state-rag__decisions_record` ×4 | id 1: phase activation; id 2: software-system evidence; id 3: way-of-working evidence; id 4: deployment scope |
+| `scripts/check-readme-inventory.sh` | Inventory consistency check |
+| `scripts/check-memom-consistency.sh` | Memom-принципы consistency |
+
+Принципы применены: **1** (AskUserQuestion ДО write), **13** (decisions через MCP), **15** (memom-запись Wave 6-7), **16** (README обновлён), **22** (active_phase через skill).
+
+## Установка / обновление
+
+```bash
+/plugin marketplace update ypolosov
+/plugin update ai-driven-sdlc
+```
+
+После update — verify в settings: версия v0.10.1.
+
+## Known issue (Wave 8 candidate)
+
+`scripts/check-alpha-consistency.sh` использует TCP `postgresql://localhost:5432` fallback вместо pglite mode → ECONNREFUSED при PostToolUse hook на pet-target (embedded pglite). Edit'ы применяются (postoolUse не откатывает), но hook ругается. Issue будет открыт отдельно.
+
+## Audit re-run после merge
+
+После squash merge release/v0.10.1 в main — рекомендуется `/sdlc-audit` для верификации `warn → pass`.


### PR DESCRIPTION
## Summary

Patch v0.10.1 — docs-only sync после Wave 6-7. PR #66 (drift cleanup, squash commit `101012e`) уже merged в main; этот PR оборачивает его в release.

**Без поведенческих изменений.** Только bump version + CHANGELOG + release-notes.

## Что в патче

- `.claude-plugin/plugin.json`: 0.10.0 → **0.10.1**.
- `CHANGELOG.md`: новая секция `[0.10.1] — 2026-05-10` (Changed + Reorganized + Why + Plugin tools used).
- `docs/release-notes/release-notes-v0.10.1.md`: подробные релиз-нотес.
- `.claude/sdlc/profile.md`: `active_phase: deployment` + history.

## Plugin tools used (принцип 12 dogfooding)

- skill `/sdlc-phase deployment` — активация фазы методологически.
- `AskUserQuestion` — принцип 1 опрос про scope ДО bump.
- `mcp__sdlc-state-rag__decisions_record` id=4 (deployment scope decision).
- `scripts/check-readme-inventory.sh` — green.
- `bats tests/unit/` — **121/121 green**.

## Test plan

- [x] `bash scripts/check-readme-inventory.sh` — OK
- [x] `bats tests/unit/` — 121/121 green
- [ ] CI workflow `lint-and-test` SUCCESS
- [ ] After merge: tag `v0.10.1` + `gh release create v0.10.1 --notes-file docs/release-notes/release-notes-v0.10.1.md`
- [ ] Marketplace update: `/plugin marketplace update ypolosov && /plugin update ai-driven-sdlc`
- [ ] Re-run `/sdlc-audit` для верификации `warn → pass`

## Wave 8 candidate (separate)

`scripts/check-alpha-consistency.sh` использует TCP postgres fallback вместо pglite — ECONNREFUSED при PostToolUse hook на pet-target. Открою отдельный issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)