### PR TITLE
fix(wave-8): #69 check-alpha-consistency.sh использует pglite на pet-target

### DIFF
--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -4,8 +4,8 @@ type: sdlc-profile
 project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
-active_phase: deployment
-active_phase_set_at: 2026-05-10T20:06:57Z
+active_phase: development
+active_phase_set_at: 2026-05-10T20:38:03Z
 ---
 
 # SME-профиль проекта
@@ -53,3 +53,4 @@ active_phase_set_at: 2026-05-10T20:06:57Z
 - 2026-05-10 — фаза development re-активирована для docs-PR drift cleanup (Wave 7 closure).
 - 2026-05-10 — `sdlc-integrations` skill (Wave 4) фиксируется как **out-of-band** cross-cutting; не отдельная фаза в SME-таблице.
 - 2026-05-10 — фаза deployment активирована для release v0.10.1 patch (PR #66 merged).
+- 2026-05-10 — фаза development активирована для Wave 8 PR-1 (#69 check-alpha-consistency hook pglite fix).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **#69 (Wave 8 P2 bug)**: `scripts/check-alpha-consistency.sh` использовал TCP `postgresql://localhost:5432/<projectname>` fallback по умолчанию, что вызывало `ECONNREFUSED 5432` на pet-target с embedded pglite (`<target>/.sdlc-db/`). Теперь script:
+  - Если `SDLC_STATE_RAG_DSN` не установлен И `<target>/.sdlc-db/` существует → exit 0 (pet/pglite mode; trust MCP server).
+  - Если ни DSN, ни pglite directory → exit 2 с helpful error (нет backend).
+  - Если DSN установлен → validate как раньше через `SDLC_STATE_RAG_VALIDATE_CMD`.
+- `tests/unit/check-alpha-consistency.bats` расширен: 5 → **8 кейсов** (+pet pglite skip; +no-DSN-no-pglite error; +DSN override pglite).
+
+### Why
+
+В Wave 7 closure session (2026-05-10) каждый Edit `.claude/sdlc/alphas.md` или `decisions.md` триггерил PostToolUse hook с `ECONNREFUSED 127.0.0.1:5432` в stdout. Edit применялся (postoolUse не откатывает), но логи засорены. Принципы 20/21 говорят «pet → pglite»; script default нарушал их.
+
 ## [0.10.1] — 2026-05-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@
   - `check-cross-refs.bats` — 6 кейсов на детектор осиротевших ссылок.
   - `enforce-no-comments.bats` — 13 кейсов (TypeScript whitelist Wave 5 + heredoc detection Wave 7).
   - `bootstrap-dev-env.bats` — 3 кейса на детектор пакетного менеджера.
-  - `check-alpha-consistency.bats` — 5 кейсов на валидатор БД через `SDLC_STATE_RAG_VALIDATE_CMD`.
+  - `check-alpha-consistency.bats` — 8 кейсов на валидатор БД (DSN/pglite mode discrimination, Wave 8 #69).
   - `check-tool-binding.bats` — 9 кейсов на проверку категорий tool-bindings (Волна 4).
   - `target-roles-schema.bats` — 14 кейсов на схему ролей и target-roles (Волна 4).
   - `detect-credentials.bats` — 6 кейсов на проверку `.env` и обязательных ключей (Волна 4).

--- a/scripts/check-alpha-consistency.sh
+++ b/scripts/check-alpha-consistency.sh
@@ -16,11 +16,21 @@ case "$file_path" in
   *) exit 0 ;;
 esac
 
+dsn="${SDLC_STATE_RAG_DSN:-}"
+pglite_dir="${cwd}/.sdlc-db"
+
+if [ -z "$dsn" ] && [ -d "$pglite_dir" ]; then
+  exit 0
+fi
+
+if [ -z "$dsn" ]; then
+  printf 'check-alpha-consistency: ни SDLC_STATE_RAG_DSN не установлен, ни pglite dir (%s) не найден; нет backend для валидации\n' "$pglite_dir" >&2
+  exit 2
+fi
+
 cmd="${SDLC_STATE_RAG_VALIDATE_CMD:-sdlc-state-rag validate}"
 log_file="$(mktemp)"
 trap 'rm -f "$log_file"' EXIT
-
-dsn="${SDLC_STATE_RAG_DSN:-postgresql://localhost/${cwd##*/}}"
 
 if ! SDLC_STATE_RAG_DSN="$dsn" $cmd >"$log_file" 2>&1; then
   printf 'check-alpha-consistency: state machine не консистентна:\n' >&2

--- a/tests/unit/check-alpha-consistency.bats
+++ b/tests/unit/check-alpha-consistency.bats
@@ -33,15 +33,36 @@ payload() {
   [ "$status" -eq 0 ]
 }
 
-@test "alphas.md with mock validate ok=true passes" {
+@test "alphas.md with mock validate ok=true passes (DSN set)" {
   echo "snapshot" > "$TMP_DIR/.claude/sdlc/alphas.md"
-  run bash -c "SDLC_STATE_RAG_VALIDATE_CMD='true' printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | SDLC_STATE_RAG_VALIDATE_CMD='true' '$SCRIPT'"
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | SDLC_STATE_RAG_DSN='postgresql://test/db' SDLC_STATE_RAG_VALIDATE_CMD='true' '$SCRIPT'"
   [ "$status" -eq 0 ]
 }
 
-@test "alphas.md with mock validate ok=false fails with exit 2" {
+@test "alphas.md with mock validate ok=false fails with exit 2 (DSN set)" {
   echo "snapshot" > "$TMP_DIR/.claude/sdlc/alphas.md"
-  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | SDLC_STATE_RAG_VALIDATE_CMD='false' '$SCRIPT'"
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | SDLC_STATE_RAG_DSN='postgresql://test/db' SDLC_STATE_RAG_VALIDATE_CMD='false' '$SCRIPT'"
   [ "$status" -eq 2 ]
+}
+
+@test "pet mode (pglite dir exists, no DSN) skips validation with exit 0" {
+  echo "snapshot" > "$TMP_DIR/.claude/sdlc/alphas.md"
+  mkdir -p "$TMP_DIR/.sdlc-db"
+  run bash -c "unset SDLC_STATE_RAG_DSN; printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "no DSN and no pglite dir fails with exit 2 and helpful error" {
+  echo "snapshot" > "$TMP_DIR/.claude/sdlc/alphas.md"
+  run bash -c "unset SDLC_STATE_RAG_DSN; printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | '$SCRIPT'"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ SDLC_STATE_RAG_DSN ]] || [[ "$output" =~ pglite ]] || [[ "$output" =~ \.sdlc-db ]]
+}
+
+@test "DSN env var overrides pglite mode (mid/enterprise)" {
+  echo "snapshot" > "$TMP_DIR/.claude/sdlc/alphas.md"
+  mkdir -p "$TMP_DIR/.sdlc-db"
+  run bash -c "printf '%s' '$(payload Write "$TMP_DIR/.claude/sdlc/alphas.md" "$TMP_DIR")' | SDLC_STATE_RAG_DSN='postgresql://test/db' SDLC_STATE_RAG_VALIDATE_CMD='true' '$SCRIPT'"
+  [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

Closes #69 — `scripts/check-alpha-consistency.sh` использовал TCP `postgresql://localhost:5432` fallback по умолчанию, что вызывало `ECONNREFUSED 5432` на pet-target с embedded pglite (нарушение принципов 20/21).

## Изменения

| File | Change |
|---|---|
| [`scripts/check-alpha-consistency.sh`](scripts/check-alpha-consistency.sh) | DSN/pglite discrimination logic |
| [`tests/unit/check-alpha-consistency.bats`](tests/unit/check-alpha-consistency.bats) | 5 → 8 кейсов |
| [`README.md`](README.md) | inventory update |
| [`CHANGELOG.md`](CHANGELOG.md) | `[Unreleased]` Fixed section |

## Логика fix

```
SDLC_STATE_RAG_DSN env?
├─ NO + .sdlc-db/ exists → exit 0 (pet/pglite mode; trust MCP server)
├─ NO + .sdlc-db/ absent → exit 2 + helpful error (нет backend)
└─ YES → validate через SDLC_STATE_RAG_VALIDATE_CMD (как раньше)
```

## TDD-first (принцип 5)

1. Расширил `tests/unit/check-alpha-consistency.bats` (5 → 8 кейсов): 2 fail (red).
2. Реализовал fix в `scripts/check-alpha-consistency.sh`.
3. Все 8 кейсов passing (green).

```
ok 1 non-Write/Edit tool is skipped
ok 2 path outside alphas.md is skipped
ok 3 alphas.md outside .claude/sdlc is skipped
ok 4 alphas.md with mock validate ok=true passes (DSN set)
ok 5 alphas.md with mock validate ok=false fails with exit 2 (DSN set)
ok 6 pet mode (pglite dir exists, no DSN) skips validation with exit 0
ok 7 no DSN and no pglite dir fails with exit 2 and helpful error
ok 8 DSN env var overrides pglite mode (mid/enterprise)
```

## Plugin tools used (принцип 12 dogfooding)

- skill `/sdlc-phase development` — фаза активирована методологически.
- `mcp__sdlc-state-rag__decisions_record` id=34 (Wave 8 PR-1 plan).
- TDD-first: red → fix → green.
- Принципы: 1, 5, 12, 20, 21, 22.

## Test plan

- [x] `bats tests/unit/check-alpha-consistency.bats` — 8/8 green
- [x] `bats tests/unit/` — **124/124 green** (было 121, +3 нач кейса)
- [x] `shellcheck scripts/check-alpha-consistency.sh` — clean
- [x] `shfmt -i 2 -ci -d scripts/check-alpha-consistency.sh` — no diff
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [ ] CI green
- [ ] After merge: release v0.11.0 patch с этим fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)