### PR TITLE
feat(wave-8): #61 iteration.meta.md kanban-style для группировки work-units

### DIFF
--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -5,7 +5,7 @@ project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
 active_phase: development
-active_phase_set_at: 2026-05-10T20:38:03Z
+active_phase_set_at: 2026-05-10T20:42:00Z
 ---
 
 # SME-профиль проекта
@@ -54,3 +54,4 @@ active_phase_set_at: 2026-05-10T20:38:03Z
 - 2026-05-10 — `sdlc-integrations` skill (Wave 4) фиксируется как **out-of-band** cross-cutting; не отдельная фаза в SME-таблице.
 - 2026-05-10 — фаза deployment активирована для release v0.10.1 patch (PR #66 merged).
 - 2026-05-10 — фаза development активирована для Wave 8 PR-1 (#69 check-alpha-consistency hook pglite fix).
+- 2026-05-10 — фаза development активирована для Wave 8 PR-2 (#61 iteration.meta.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- **#61 (Wave 8 P2 Gap-8)**: `meta-templates/iteration.meta.md` — kanban-style meta-template для группировки work-units в итерации (sprint или milestone). Поля frontmatter:
+  - `iteration_id`, `sprint_or_milestone`, `status` (planned/in-progress/completed)
+  - `work_units` — массив ссылок на work-unit-артефакты
+  - `start_date`, `end_date`
+  - Опциональные kanban-метрики: `wip_limit`, `cycle_time_avg`, `velocity`
+- `tests/unit/iteration-template.bats` — 10 кейсов (existence, frontmatter, kanban states, alphas).
+
 ### Fixed
 
 - **#69 (Wave 8 P2 bug)**: `scripts/check-alpha-consistency.sh` использовал TCP `postgresql://localhost:5432/<projectname>` fallback по умолчанию, что вызывало `ECONNREFUSED 5432` на pet-target с embedded pglite (`<target>/.sdlc-db/`). Теперь script:
@@ -15,7 +24,7 @@
 
 ### Why
 
-В Wave 7 closure session (2026-05-10) каждый Edit `.claude/sdlc/alphas.md` или `decisions.md` триггерил PostToolUse hook с `ECONNREFUSED 127.0.0.1:5432` в stdout. Edit применялся (postoolUse не откатывает), но логи засорены. Принципы 20/21 говорят «pet → pglite»; script default нарушал их.
+Wave 8 P2 issues из gt-validation backlog (#61 Gap-8 + #69 hook bug). #61: плагин не имел meta-template для kanban-style итерационных декомпозиций (`docs/architecture/iterations/` в gt). #69: Edit `.claude/sdlc/alphas.md` триггерил `ECONNREFUSED 5432` на pet-target с embedded pglite — принципы 20/21 нарушены.
 
 ## [0.10.1] — 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
 - `launch-sdlc-state-rag.sh` — launcher MCP-сервера sdlc-state-rag с fallback PATH→nvm→standard locations→npx (v0.5.2).
 - `check-adr-paths.sh` — валидирует `adr_paths` в `plugin-config.md` целевого (Волна 6, v0.6.0).
 
-### Meta-templates (24: 19 top + 5 external-systems)
+### Meta-templates (25: 20 top + 5 external-systems)
 - `work-product.meta.md` — базовая схема рабочего продукта.
 - `phase-artifact.meta.md` — схема любого артефакта фазы.
 - `profile.meta.md` — схема SME-выбора целевого.
@@ -130,6 +130,7 @@
 - `work-unit.jira.meta.md` — схема work-unit для Jira-managed целевых (Волна 7, v0.9.0, Gap-6).
 - `work-unit.linear.meta.md` — схема work-unit для Linear-managed целевых (Волна 7, v0.9.0, Gap-6).
 - `work-unit.github.meta.md` — схема work-unit для GitHub Issues-managed целевых (Волна 7, v0.9.0, Gap-6).
+- `iteration.meta.md` — схема итерации (kanban-style) для группировки work-units (Wave 8, #61, Gap-8).
 
 #### External-system references (`meta-templates/external-systems/`, Волна 7 v0.10.0)
 - `issue-tracker.jira.md` — Atlassian Rovo / sooperset/mcp-atlassian.
@@ -183,6 +184,7 @@
   - `bootstrap-role-extensions.bats` — 4 кейса на создание `role-extensions.md` placeholder при /sdlc-init (Волна 7, v0.8.0).
   - `work-unit-templates.bats` — 7 кейсов на 3 work-unit meta-templates (Jira/Linear/GitHub) (Волна 7, v0.9.0).
   - `external-systems-references.bats` — 10 кейсов на 5 reference MCP-серверов (Волна 7, v0.10.0).
+  - `iteration-template.bats` — 10 кейсов на iteration meta-template (Wave 8, #61, Gap-8).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/meta-templates/iteration.meta.md
+++ b/meta-templates/iteration.meta.md
@@ -1,0 +1,99 @@
+---
+name: iteration.meta
+type: meta-template
+scope: схема итерации (kanban-style) для группировки work-units
+extends: work-product.meta.md
+location_in_target: .claude/sdlc/phases/requirements/iterations/<iteration-id>.md
+source: Wave 8 #61 Gap-8 (gt-validation)
+---
+
+# Мета-шаблон итерации (kanban-style)
+
+Используется для kanban-style декомпозиции work'ов по sprint'ам или milestone'ам.
+Связывает несколько work-unit-артефактов в одну итерацию с временным окном.
+
+## Обязательный frontmatter
+
+```yaml
+---
+name: <iteration-slug>
+type: iteration
+phase: requirements
+project: <target-project>
+iteration_id: <ITER-N или sprint-name>
+sprint_or_milestone: <sprint-name | milestone-name | null>
+status: <planned|in-progress|completed>
+work_units: [<ссылки на work-unit-артефакты>]
+start_date: <YYYY-MM-DD>
+end_date: <YYYY-MM-DD>
+sme_level: <pet|mid|enterprise>
+alphas: [Work, Requirements]
+role: <product-owner|method-engineer>
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+```
+
+## Status enum (kanban-states)
+
+- `planned` — итерация определена, но не начата.
+- `in-progress` — активная итерация; work-units в работе.
+- `completed` — все work-units закрыты; итерация завершена.
+
+## Обязательные секции
+
+### 1. Назначение
+
+Одно утверждение, какую цель преследует итерация (бизнес-смысл).
+
+### 2. Включённые work-units
+
+Markdown-таблица или bullet-list ссылок на work-unit-артефакты.
+Каждая ссылка указывает имя и текущий статус.
+
+### 3. Acceptance Criteria итерации
+
+Что считается «итерация завершена» — суммарные критерии готовности.
+
+### 4. Связи с другими артефактами
+
+- `traces_from`: vision/requirements какие drove'ят итерацию.
+- `traces_to`: testing/deployment где проверяется завершённость.
+
+### 5. Критерии готовности
+
+Fitness-функции итерации:
+- Все work-units в статусе `completed` или `cancelled`.
+- AC выполнены и подтверждены тестами.
+- Demo проведено если применимо.
+
+## Поля специфичные для kanban
+
+- `wip_limit` (опционально) — максимум work-units в `in-progress` одновременно.
+- `cycle_time_avg` (опционально) — среднее время прохождения work-unit через итерацию.
+- `velocity` (опционально) — story-points или count work-units завершённых.
+
+## Привязка к альфам
+
+Итерация продвигает:
+- `Work` (Initiated → Under Control → Concluded для каждого work-unit).
+- `Requirements` (постепенно от Conceived через Bounded к Acceptable).
+
+## Правила
+
+- Создание через skill `sdlc-requirements` (опционально по pet/mid/enterprise scope).
+- AskUserQuestion перед write (принцип 1).
+- `work_units` ссылается только на существующие work-unit-артефакты в `<target>/.claude/sdlc/phases/requirements/`.
+- Pet-проекты могут пропустить итерации; mid+ обычно используют.
+
+## Валидация
+
+`validate-artifact.sh` + проверка enum `status` и формата `start_date`/`end_date`.
+
+## Pet vs Mid vs Enterprise
+
+| Уровень | Использование |
+|---|---|
+| pet | Опционально; обычно один global iteration на проект. |
+| mid | Sprint-based (2-week iterations) или milestone-based. |
+| enterprise | PI (Program Increment) или quarter-based; multiple parallel iterations. |

--- a/tests/unit/iteration-template.bats
+++ b/tests/unit/iteration-template.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  TEMPLATE="$REPO_ROOT/meta-templates/iteration.meta.md"
+}
+
+@test "iteration.meta.md exists" {
+  [ -f "$TEMPLATE" ]
+}
+
+@test "iteration.meta.md has correct frontmatter type meta-template" {
+  run grep -E "^type: meta-template$" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "iteration.meta.md extends work-product.meta.md" {
+  run grep -E "^extends: work-product\.meta\.md$" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "iteration.meta.md frontmatter declares iteration_id field" {
+  run grep -E "iteration_id" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "iteration.meta.md frontmatter declares status field with kanban states" {
+  grep -q "status" "$TEMPLATE"
+  grep -q "planned" "$TEMPLATE"
+  grep -q "in-progress" "$TEMPLATE"
+  grep -q "completed" "$TEMPLATE"
+}
+
+@test "iteration.meta.md frontmatter declares work_units field" {
+  run grep -E "work_units" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "iteration.meta.md declares start_date and end_date" {
+  grep -q "start_date" "$TEMPLATE"
+  grep -q "end_date" "$TEMPLATE"
+}
+
+@test "iteration.meta.md declares alphas Work" {
+  run grep -E "alphas:.*Work" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "iteration.meta.md mentions sprint or milestone" {
+  grep -qE "sprint|milestone" "$TEMPLATE"
+}
+
+@test "README.md mentions iteration.meta.md" {
+  run grep -E "iteration\.meta\.md" "$REPO_ROOT/README.md"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Closes #61 (Wave 8 P2 Gap-8) — плагин не имел meta-template для kanban-style итерационных декомпозиций.

## Что добавлено

### `meta-templates/iteration.meta.md`

Extends `work-product.meta.md`. Frontmatter:
- `iteration_id`, `sprint_or_milestone`, `status` (planned/in-progress/completed)
- `work_units` — массив ссылок на work-unit-артефакты
- `start_date`, `end_date`
- Опциональные kanban-метрики: `wip_limit`, `cycle_time_avg`, `velocity`

### Pet/mid/enterprise scope

| Уровень | Использование |
|---|---|
| pet | Опционально; обычно один global iteration. |
| mid | Sprint-based (2-week iterations) или milestone-based. |
| enterprise | PI (Program Increment) или quarter-based; multiple parallel iterations. |

## TDD-first (принцип 5)

1. `tests/unit/iteration-template.bats` — 10 кейсов (red).
2. Создал `meta-templates/iteration.meta.md`.
3. Все 10/10 green.

```
ok 1 iteration.meta.md exists
ok 2 iteration.meta.md has correct frontmatter type meta-template
ok 3 iteration.meta.md extends work-product.meta.md
ok 4 iteration.meta.md frontmatter declares iteration_id field
ok 5 iteration.meta.md frontmatter declares status field with kanban states
ok 6 iteration.meta.md frontmatter declares work_units field
ok 7 iteration.meta.md declares start_date and end_date
ok 8 iteration.meta.md declares alphas Work
ok 9 iteration.meta.md mentions sprint or milestone
ok 10 README.md mentions iteration.meta.md
```

## README updates

- Meta-templates: **24 → 25** (20 top + 5 external-systems)
- Добавлен `iteration-template.bats` в Tests&CI

## Plugin tools used (принцип 12 dogfooding)

- skill `/sdlc-phase development` — фаза активирована методологически.
- `mcp__sdlc-state-rag__decisions_record` id=35 (Wave 8 PR-2 plan).
- TDD-first: red → fix → green.

## Test plan

- [x] `bats tests/unit/iteration-template.bats` — 10/10 green
- [x] `bats tests/unit/` — **131/131 green** (было 121, +10)
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [ ] CI green
- [ ] After merge: будет включено в release v0.11.0 минор-bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)