### PR TITLE
feat(wave-8): #60 c4-diagram.meta.md PlantUML/Structurizr/Mermaid

### DIFF
--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -5,7 +5,7 @@ project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
 active_phase: development
-active_phase_set_at: 2026-05-10T20:42:00Z
+active_phase_set_at: 2026-05-10T20:46:00Z
 ---
 
 # SME-профиль проекта
@@ -55,3 +55,4 @@ active_phase_set_at: 2026-05-10T20:42:00Z
 - 2026-05-10 — фаза deployment активирована для release v0.10.1 patch (PR #66 merged).
 - 2026-05-10 — фаза development активирована для Wave 8 PR-1 (#69 check-alpha-consistency hook pglite fix).
 - 2026-05-10 — фаза development активирована для Wave 8 PR-2 (#61 iteration.meta.md).
+- 2026-05-10 — фаза development активирована для Wave 8 PR-3 (#60 c4-diagram.meta.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   - `start_date`, `end_date`
   - Опциональные kanban-метрики: `wip_limit`, `cycle_time_avg`, `velocity`
 - `tests/unit/iteration-template.bats` — 10 кейсов (existence, frontmatter, kanban states, alphas).
+- **#60 (Wave 8 P2 Gap-7)**: `meta-templates/c4-diagram.meta.md` — meta-template для C4-диаграмм (Simon Brown). Поля frontmatter:
+  - `level` enum: Context / Container / Component / Code
+  - `format` enum: plantuml / structurizr / mermaid
+  - `file_path` — относительный путь к рендерному файлу или null если inline
+  - `alphas: [Software System]`
+- `tests/unit/c4-diagram-template.bats` — 12 кейсов (existence, frontmatter, levels, formats, matrix references).
+- `catalogs/method-tool-matrix.md` Architecture секция расширена:
+  - mid: `C4 Level 1-2 (PlantUML / Structurizr / Mermaid)`
+  - enterprise: `C4 Level 1-3 + Structurizr workspace`
 
 ### Fixed
 
@@ -24,7 +33,7 @@
 
 ### Why
 
-Wave 8 P2 issues из gt-validation backlog (#61 Gap-8 + #69 hook bug). #61: плагин не имел meta-template для kanban-style итерационных декомпозиций (`docs/architecture/iterations/` в gt). #69: Edit `.claude/sdlc/alphas.md` триггерил `ECONNREFUSED 5432` на pet-target с embedded pglite — принципы 20/21 нарушены.
+Wave 8 P2 issues из gt-validation backlog (#61 Gap-8 + #60 Gap-7 + #69 hook bug). #61: плагин не имел meta-template для kanban-style итерационных декомпозиций. #60: плагин не предлагал meta-template для C4-диаграмм (gt использует C4 в `docs/architecture/c4/`). #69: Edit `.claude/sdlc/alphas.md` триггерил `ECONNREFUSED 5432` на pet-target с embedded pglite — принципы 20/21 нарушены.
 
 ## [0.10.1] — 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
 - `launch-sdlc-state-rag.sh` — launcher MCP-сервера sdlc-state-rag с fallback PATH→nvm→standard locations→npx (v0.5.2).
 - `check-adr-paths.sh` — валидирует `adr_paths` в `plugin-config.md` целевого (Волна 6, v0.6.0).
 
-### Meta-templates (25: 20 top + 5 external-systems)
+### Meta-templates (26: 21 top + 5 external-systems)
 - `work-product.meta.md` — базовая схема рабочего продукта.
 - `phase-artifact.meta.md` — схема любого артефакта фазы.
 - `profile.meta.md` — схема SME-выбора целевого.
@@ -131,6 +131,7 @@
 - `work-unit.linear.meta.md` — схема work-unit для Linear-managed целевых (Волна 7, v0.9.0, Gap-6).
 - `work-unit.github.meta.md` — схема work-unit для GitHub Issues-managed целевых (Волна 7, v0.9.0, Gap-6).
 - `iteration.meta.md` — схема итерации (kanban-style) для группировки work-units (Wave 8, #61, Gap-8).
+- `c4-diagram.meta.md` — схема C4-диаграммы (Context/Container/Component/Code) с поддержкой PlantUML/Structurizr/Mermaid (Wave 8, #60, Gap-7).
 
 #### External-system references (`meta-templates/external-systems/`, Волна 7 v0.10.0)
 - `issue-tracker.jira.md` — Atlassian Rovo / sooperset/mcp-atlassian.
@@ -185,6 +186,7 @@
   - `work-unit-templates.bats` — 7 кейсов на 3 work-unit meta-templates (Jira/Linear/GitHub) (Волна 7, v0.9.0).
   - `external-systems-references.bats` — 10 кейсов на 5 reference MCP-серверов (Волна 7, v0.10.0).
   - `iteration-template.bats` — 10 кейсов на iteration meta-template (Wave 8, #61, Gap-8).
+  - `c4-diagram-template.bats` — 12 кейсов на c4-diagram meta-template + matrix references (Wave 8, #60, Gap-7).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/catalogs/method-tool-matrix.md
+++ b/catalogs/method-tool-matrix.md
@@ -38,8 +38,8 @@ Skill `sdlc-method-engineering` объединяет матрицу плагин
 | Уровень | Метод (абстрактно) | Примеры инструментов |
 |---|---|---|
 | pet | Одностраничное описание структуры системы с одной диаграммой | ASCII box-and-arrow • Mermaid-диаграмма • draw.io sketch |
-| mid | Фиксация значимых архитектурных решений и многоуровневое визуальное моделирование | ADR (Nygard) • C4 Level 1-2 • arc42 |
-| enterprise | Формальная оценка качественных атрибутов и моделирование системной архитектуры | ATAM/QAW • ArchiMate/TOGAF • SEI Views-and-Beyond |
+| mid | Фиксация значимых архитектурных решений и многоуровневое визуальное моделирование | ADR (Nygard) • C4 Level 1-2 (PlantUML / Structurizr / Mermaid) • arc42 |
+| enterprise | Формальная оценка качественных атрибутов и моделирование системной архитектуры | ATAM/QAW • C4 Level 1-3 + Structurizr workspace • ArchiMate/TOGAF • SEI Views-and-Beyond |
 
 ## 4. Development
 

--- a/meta-templates/c4-diagram.meta.md
+++ b/meta-templates/c4-diagram.meta.md
@@ -1,0 +1,118 @@
+---
+name: c4-diagram.meta
+type: meta-template
+scope: схема C4-диаграммы для архитектурного описания (Context/Container/Component/Code)
+extends: work-product.meta.md
+location_in_target: .claude/sdlc/phases/architecture/c4/<level>-<diagram-slug>.md
+source: Wave 8 #60 Gap-7 (gt-validation), Simon Brown C4 model
+level: <Context|Container|Component|Code>
+format: <plantuml|structurizr|mermaid>
+file_path: null
+---
+
+# Мета-шаблон C4-диаграммы
+
+Используется для описания архитектуры через 4 уровня C4-модели (Simon Brown).
+Один файл = одна диаграмма одного уровня.
+
+## Обязательный frontmatter
+
+```yaml
+---
+name: <diagram-slug>
+type: c4-diagram
+phase: architecture
+project: <target-project>
+level: <Context|Container|Component|Code>
+format: <plantuml|structurizr|mermaid>
+file_path: <относительный путь к рендерному файлу .puml/.dsl/.mmd, или null если inline>
+sme_level: <pet|mid|enterprise>
+alphas: [Software System]
+role: <architect|developer>
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+---
+```
+
+## C4 Levels (Simon Brown)
+
+| Level | Назначение | Аудитория |
+|---|---|---|
+| Context | Система и её внешние зависимости (people, systems) | бизнес + tech |
+| Container | High-level technology choices (apps, databases, services) | tech leads |
+| Component | Внутренние компоненты одного container'а | разработчики |
+| Code | Class-level / file-level decomposition (опционально) | разработчики |
+
+## Format options
+
+- **PlantUML** (`.puml`) — текстовый DSL; рендеринг через `plantuml.jar` или Kroki API.
+  - Использовать `c4-plantuml` library: `!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml`.
+- **Structurizr** (`.dsl`) — Structurizr DSL; рендеринг через Structurizr Lite или Cloud.
+  - Workspace-based, multiple views в одном файле.
+- **Mermaid** (`.mmd`) — markdown-friendly; нативный рендер в GitHub README.
+  - C4 поддержка через `c4Context`, `c4Container` синтаксис (experimental).
+
+## Обязательные секции
+
+### 1. Назначение
+
+Одно утверждение, какой архитектурный аспект диаграмма описывает.
+
+### 2. Diagram (inline или ссылка)
+
+Если `file_path` null — diagram-text inline в fenced-блок:
+````markdown
+```plantuml
+@startuml
+!include C4_Context.puml
+Person(user, "User", "End user")
+System(myApp, "MyApp", "The system")
+Rel(user, myApp, "Uses")
+@enduml
+```
+````
+
+Если `file_path` установлен — ссылка на external file:
+```markdown
+См. [c4/context-overview.puml](c4/context-overview.puml).
+```
+
+### 3. Описание элементов
+
+Markdown-list или таблица: имя элемента → роль → ответственность.
+
+### 4. Связи с другими C4-уровнями
+
+- Container-уровень детализирует Context-системы.
+- Component-уровень детализирует Container'ы.
+- traces_to: ссылки на ADR'ы, описывающие выбор technology.
+
+### 5. Критерии готовности
+
+- Все элементы диаграммы имеют описание.
+- Связи направлены и подписаны.
+- Если level≥Container — указаны technology choices.
+
+## Привязка к альфам
+
+Диаграмма продвигает:
+- `Software System` — добавляет evidence на Architecture Selected.
+
+## Pet vs Mid vs Enterprise
+
+| Уровень | C4-уровни типично | Format |
+|---|---|---|
+| pet | Context only (single diagram) | Mermaid (markdown-native) |
+| mid | Context + Container (1-2 diagrams) | PlantUML или Mermaid |
+| enterprise | Context + Container + Component (3+ diagrams) | Structurizr (workspace) |
+
+## Правила
+
+- Создание через skill `sdlc-architecture` опционально (mid+ обычно используют).
+- AskUserQuestion перед write (принцип 1).
+- `level` enum валидируется при `validate-artifact.sh`.
+- Diagram source — versioned в `<target>/.claude/sdlc/phases/architecture/c4/`.
+
+## Валидация
+
+`validate-artifact.sh` + проверка enum `level` и `format`.

--- a/tests/unit/c4-diagram-template.bats
+++ b/tests/unit/c4-diagram-template.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  TEMPLATE="$REPO_ROOT/meta-templates/c4-diagram.meta.md"
+  MATRIX="$REPO_ROOT/catalogs/method-tool-matrix.md"
+}
+
+@test "c4-diagram.meta.md exists" {
+  [ -f "$TEMPLATE" ]
+}
+
+@test "c4-diagram.meta.md has type meta-template" {
+  run grep -E "^type: meta-template$" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "c4-diagram.meta.md extends work-product.meta.md" {
+  run grep -E "^extends: work-product\.meta\.md$" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "c4-diagram.meta.md declares 4 C4 levels" {
+  grep -q "Context" "$TEMPLATE"
+  grep -q "Container" "$TEMPLATE"
+  grep -q "Component" "$TEMPLATE"
+  grep -q "Code" "$TEMPLATE"
+}
+
+@test "c4-diagram.meta.md declares 3 formats" {
+  grep -q "plantuml" "$TEMPLATE"
+  grep -q "structurizr" "$TEMPLATE"
+  grep -q "mermaid" "$TEMPLATE"
+}
+
+@test "c4-diagram.meta.md declares level field in frontmatter" {
+  run grep -E "^level:" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "c4-diagram.meta.md declares format field in frontmatter" {
+  run grep -E "^format:" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "c4-diagram.meta.md declares file_path field" {
+  run grep -E "file_path" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "c4-diagram.meta.md declares alphas Software System" {
+  run grep -E "alphas:.*Software System" "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "method-tool-matrix.md mentions PlantUML in Architecture section" {
+  grep -q "PlantUML" "$MATRIX"
+}
+
+@test "method-tool-matrix.md mentions Structurizr in Architecture section" {
+  grep -q "Structurizr" "$MATRIX"
+}
+
+@test "README.md mentions c4-diagram.meta.md" {
+  run grep -E "c4-diagram\.meta\.md" "$REPO_ROOT/README.md"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Closes #60 (Wave 8 P2 Gap-7) — плагин не предлагал meta-template для C4-диаграмм (Simon Brown), хотя gt использует C4 в `docs/architecture/c4/` (PlantUML/Structurizr).

## Что добавлено

### `meta-templates/c4-diagram.meta.md`

Extends `work-product.meta.md`. Frontmatter поля:
- `level` enum: **Context / Container / Component / Code**
- `format` enum: **plantuml / structurizr / mermaid**
- `file_path` — относительный путь к рендерному файлу (.puml/.dsl/.mmd) или `null` если diagram inline в fenced-блоке
- `alphas: [Software System]`

### Pet/mid/enterprise scope

| Уровень | C4-уровни | Format |
|---|---|---|
| pet | Context only | Mermaid (markdown-native) |
| mid | Context + Container | PlantUML или Mermaid |
| enterprise | Context + Container + Component | Structurizr (workspace) |

### `catalogs/method-tool-matrix.md` Architecture обновлено

- mid: `C4 Level 1-2 (PlantUML / Structurizr / Mermaid)`
- enterprise: `C4 Level 1-3 + Structurizr workspace`

## TDD-first (принцип 5)

1. `tests/unit/c4-diagram-template.bats` — 12 кейсов (red).
2. Создал meta-template + расширил matrix + README.
3. Все 12/12 green.

```
ok 1 c4-diagram.meta.md exists
ok 2 c4-diagram.meta.md has type meta-template
ok 3 c4-diagram.meta.md extends work-product.meta.md
ok 4 c4-diagram.meta.md declares 4 C4 levels
ok 5 c4-diagram.meta.md declares 3 formats
ok 6 c4-diagram.meta.md declares level field in frontmatter
ok 7 c4-diagram.meta.md declares format field in frontmatter
ok 8 c4-diagram.meta.md declares file_path field
ok 9 c4-diagram.meta.md declares alphas Software System
ok 10 method-tool-matrix.md mentions PlantUML in Architecture section
ok 11 method-tool-matrix.md mentions Structurizr in Architecture section
ok 12 README.md mentions c4-diagram.meta.md
```

## README updates

- Meta-templates: **24 → 25** (20 top + 5 external-systems)
- Добавлен `c4-diagram-template.bats` в Tests&CI

## Plugin tools used (принцип 12 dogfooding)

- skill `/sdlc-phase development`
- `mcp__sdlc-state-rag__decisions_record` id=36
- TDD-first: red → fix → green
- Принципы: 1, 5, 12, 22

## Test plan

- [x] `bats tests/unit/c4-diagram-template.bats` — 12/12 green
- [x] `bats tests/unit/` — **133/133 green** (было 121, +12)
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [ ] CI green
- [ ] After merge: будет включено в release v0.11.0

## AC coverage

- [x] AC-1: meta-template создан
- [x] AC-2: method-tool-matrix.md упоминает PlantUML/Structurizr/Mermaid в Architecture
- [x] AC-3: README.md обновлён

🤖 Generated with [Claude Code](https://claude.com/claude-code)