### PR TITLE
fix(wave-8): #59 bootstrap создаёт валидные frontmatter (не placeholder)

### DIFF
--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -5,7 +5,7 @@ project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
 active_phase: development
-active_phase_set_at: 2026-05-10T20:46:00Z
+active_phase_set_at: 2026-05-10T20:50:00Z
 ---
 
 # SME-профиль проекта
@@ -56,3 +56,4 @@ active_phase_set_at: 2026-05-10T20:46:00Z
 - 2026-05-10 — фаза development активирована для Wave 8 PR-1 (#69 check-alpha-consistency hook pglite fix).
 - 2026-05-10 — фаза development активирована для Wave 8 PR-2 (#61 iteration.meta.md).
 - 2026-05-10 — фаза development активирована для Wave 8 PR-3 (#60 c4-diagram.meta.md).
+- 2026-05-10 — фаза development активирована для Wave 8 PR-4 (#59 bootstrap valid frontmatter).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,23 @@
   - Если ни DSN, ни pglite directory → exit 2 с helpful error (нет backend).
   - Если DSN установлен → validate как раньше через `SDLC_STATE_RAG_VALIDATE_CMD`.
 - `tests/unit/check-alpha-consistency.bats` расширен: 5 → **8 кейсов** (+pet pglite skip; +no-DSN-no-pglite error; +DSN override pglite).
+- **#59 (Wave 8 P2 Gap-5)**: `scripts/bootstrap-target.sh` теперь создаёт 6 артефактов целевого с **валидными `type:` полями** (не `type: placeholder`). После `/sdlc-init` файлы проходят `validate-artifact.sh`:
+  - `profile.md` → `type: sdlc-profile`
+  - `plugin-config.md` → `type: hooks-config`
+  - `alphas.md` → `type: alpha-snapshot`
+  - `system-context.md` → `type: attention-context`
+  - `roles.md` → `type: role-journal`
+  - `decisions.md` → `type: decision-journal`
+- Добавлены минимальные обязательные поля в каждый frontmatter (`project`, `created`, `updated`; `version` для plugin-config; `source_of_truth`/`snapshot_role` для alphas; `current_focus` для system-context; `active_roles: []` для roles).
+
+### Changed
+
+- `scripts/bootstrap-target.sh`: удалён мёртвый код (unused `write_if_absent` function, unused `templates_root` variable). shellcheck + shfmt clean.
+- `tests/unit/bootstrap-valid-frontmatter.bats` — 8 новых кейсов (existence × 6 + no-placeholder + project field).
 
 ### Why
 
-Wave 8 P2 issues из gt-validation backlog (#61 Gap-8 + #60 Gap-7 + #69 hook bug). #61: плагин не имел meta-template для kanban-style итерационных декомпозиций. #60: плагин не предлагал meta-template для C4-диаграмм (gt использует C4 в `docs/architecture/c4/`). #69: Edit `.claude/sdlc/alphas.md` триггерил `ECONNREFUSED 5432` на pet-target с embedded pglite — принципы 20/21 нарушены.
+Wave 8 P2 issues из gt-validation backlog (#61 Gap-8 + #60 Gap-7 + #69 hook bug + #59 Gap-5). #61: плагин не имел meta-template для kanban-style итерационных декомпозиций. #60: плагин не предлагал meta-template для C4-диаграмм. #69: Edit `.claude/sdlc/alphas.md` триггерил `ECONNREFUSED 5432` на pet-target с embedded pglite. #59: bootstrap создавал placeholder frontmatter, который validate-artifact.sh отклонял как невалидный.
 
 ## [0.10.1] — 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
   - `external-systems-references.bats` — 10 кейсов на 5 reference MCP-серверов (Волна 7, v0.10.0).
   - `iteration-template.bats` — 10 кейсов на iteration meta-template (Wave 8, #61, Gap-8).
   - `c4-diagram-template.bats` — 12 кейсов на c4-diagram meta-template + matrix references (Wave 8, #60, Gap-7).
+  - `bootstrap-valid-frontmatter.bats` — 8 кейсов на валидные frontmatter из bootstrap (Wave 8, #59, Gap-5).
 - Integration (bats-core) — `tests/integration/` (3 файла, 47 кейсов):
   - `context-aggregator-mid.bats` — 20 кейсов на топологию aggregator+router и фикстуру `mid-target/` (Волна 4, ADR-010).
   - `sdlc-state-rag-contract.bats` — 23 кейса на контракт sdlc-state-rag, переключение трекера, bash-wrapper для launcher (Волна 5, ADR-011, v0.5.3).

--- a/scripts/bootstrap-target.sh
+++ b/scripts/bootstrap-target.sh
@@ -4,12 +4,10 @@ set -euo pipefail
 target="${1:-$PWD}"
 mode="${2:-fail-if-exists}"
 
-plugin_root="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-templates_root="${plugin_root}/meta-templates"
 sdlc_dir="${target}/.claude/sdlc"
 
 case "$mode" in
-  fail-if-exists|merge|force) ;;
+  fail-if-exists | merge | force) ;;
   *)
     printf 'bootstrap-target: неизвестный режим %s\n' "$mode" >&2
     exit 2
@@ -33,22 +31,10 @@ fi
 
 mkdir -p "$sdlc_dir"
 
-write_if_absent() {
-  local dest="$1"
-  local source="$2"
-  if [ -e "$dest" ] && [ "$mode" = "merge" ]; then
-    return 0
-  fi
-  if [ -e "$dest" ] && [ "$mode" = "fail-if-exists" ]; then
-    return 0
-  fi
-  cp "$source" "$dest"
-}
-
 target_claude_md="${target}/.claude/CLAUDE.md"
 mkdir -p "${target}/.claude"
 if [ ! -f "$target_claude_md" ]; then
-  cat > "$target_claude_md" <<'EOF'
+  cat >"$target_claude_md" <<'EOF'
 ---
 name: target-project-constitution
 type: project-constitution
@@ -73,27 +59,113 @@ language: ru
 EOF
 fi
 
-for f in profile plugin-config alphas system-context roles decisions; do
-  dest="${sdlc_dir}/${f}.md"
-  if [ -f "$dest" ]; then continue; fi
-  cat > "$dest" <<EOF
+project_name="$(basename "$target")"
+today="$(date +%Y-%m-%d)"
+
+if [ ! -f "${sdlc_dir}/profile.md" ]; then
+  cat >"${sdlc_dir}/profile.md" <<EOF
 ---
-name: ${f}
-type: placeholder
-project: $(basename "$target")
-created: $(date +%Y-%m-%d)
-updated: $(date +%Y-%m-%d)
+name: profile
+type: sdlc-profile
+project: ${project_name}
+created: ${today}
+updated: ${today}
 ---
 
-# ${f}
+# SME-профиль проекта
 
-Placeholder. Заполняется skill \`sdlc-bootstrap\` через /sdlc-init.
+Заполняется skill \`sdlc-bootstrap\` через /sdlc-init.
 EOF
-done
+fi
+
+if [ ! -f "${sdlc_dir}/plugin-config.md" ]; then
+  cat >"${sdlc_dir}/plugin-config.md" <<EOF
+---
+name: plugin-config
+type: hooks-config
+project: ${project_name}
+version: 1
+created: ${today}
+updated: ${today}
+---
+
+# Технический конфиг hooks
+
+Заполняется skill \`sdlc-bootstrap\` через /sdlc-init.
+EOF
+fi
+
+if [ ! -f "${sdlc_dir}/alphas.md" ]; then
+  cat >"${sdlc_dir}/alphas.md" <<EOF
+---
+name: alphas
+type: alpha-snapshot
+project: ${project_name}
+source_of_truth: mcp://sdlc-state-rag
+snapshot_role: pr-visible-mirror
+created: ${today}
+updated: ${today}
+---
+
+# Snapshot состояний альф
+
+Заполняется skill \`sdlc-bootstrap\` через /sdlc-init.
+EOF
+fi
+
+if [ ! -f "${sdlc_dir}/system-context.md" ]; then
+  cat >"${sdlc_dir}/system-context.md" <<EOF
+---
+name: system-context
+type: attention-context
+project: ${project_name}
+current_focus: ${project_name}
+created: ${today}
+updated: ${today}
+---
+
+# Реестр систем внимания
+
+Заполняется skill \`sdlc-focus\` через /sdlc-focus.
+EOF
+fi
+
+if [ ! -f "${sdlc_dir}/roles.md" ]; then
+  cat >"${sdlc_dir}/roles.md" <<EOF
+---
+name: roles
+type: role-journal
+project: ${project_name}
+active_roles: []
+created: ${today}
+updated: ${today}
+---
+
+# Журнал играемых ролей
+
+Заполняется skill \`sdlc-bootstrap\` через /sdlc-init.
+EOF
+fi
+
+if [ ! -f "${sdlc_dir}/decisions.md" ]; then
+  cat >"${sdlc_dir}/decisions.md" <<EOF
+---
+name: decisions
+type: decision-journal
+project: ${project_name}
+created: ${today}
+updated: ${today}
+---
+
+# Журнал альтернатив и решений
+
+Заполняется skills фаз через AskUserQuestion и MCP \`decisions_record\`.
+EOF
+fi
 
 role_ext_dest="${sdlc_dir}/role-extensions.md"
 if [ ! -f "$role_ext_dest" ]; then
-  cat > "$role_ext_dest" <<EOF
+  cat >"$role_ext_dest" <<EOF
 ---
 name: role-extensions
 type: target-role-mapping
@@ -134,7 +206,7 @@ fi
 
 env_example="${target}/.env.example"
 if [ ! -f "$env_example" ]; then
-  cat > "$env_example" <<'EOF'
+  cat >"$env_example" <<'EOF'
 # Пример .env.example — значения не коммитить в git.
 # Скопируйте в .env и заполните по ходу фаз.
 EOF
@@ -143,7 +215,7 @@ fi
 gitignore="${target}/.gitignore"
 touch "$gitignore"
 if ! grep -qE '^\.env$' "$gitignore"; then
-  cat >> "$gitignore" <<'EOF'
+  cat >>"$gitignore" <<'EOF'
 
 # ai-driven-sdlc: credentials (принцип 10)
 .env

--- a/tests/unit/bootstrap-valid-frontmatter.bats
+++ b/tests/unit/bootstrap-valid-frontmatter.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/bootstrap-target.sh"
+  TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+run_bootstrap() {
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT" bash "$SCRIPT" "$TMP_DIR" fail-if-exists >/dev/null 2>&1 || true
+}
+
+@test "bootstrap creates profile.md with type sdlc-profile (not placeholder)" {
+  run_bootstrap
+  run grep -E "^type: sdlc-profile$" "$TMP_DIR/.claude/sdlc/profile.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "bootstrap creates plugin-config.md with type hooks-config" {
+  run_bootstrap
+  run grep -E "^type: hooks-config$" "$TMP_DIR/.claude/sdlc/plugin-config.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "bootstrap creates alphas.md with type alpha-snapshot" {
+  run_bootstrap
+  run grep -E "^type: alpha-snapshot$" "$TMP_DIR/.claude/sdlc/alphas.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "bootstrap creates system-context.md with type attention-context" {
+  run_bootstrap
+  run grep -E "^type: attention-context$" "$TMP_DIR/.claude/sdlc/system-context.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "bootstrap creates roles.md with type role-journal" {
+  run_bootstrap
+  run grep -E "^type: role-journal$" "$TMP_DIR/.claude/sdlc/roles.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "bootstrap creates decisions.md with type decision-journal" {
+  run_bootstrap
+  run grep -E "^type: decision-journal$" "$TMP_DIR/.claude/sdlc/decisions.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "no artifact has type placeholder after bootstrap" {
+  run_bootstrap
+  run grep -rE "^type: placeholder$" "$TMP_DIR/.claude/sdlc/"
+  [ "$status" -ne 0 ]
+}
+
+@test "all 6 artifacts have project field matching target basename" {
+  run_bootstrap
+  expected="$(basename "$TMP_DIR")"
+  for f in profile plugin-config alphas system-context roles decisions; do
+    grep -qE "^project: ${expected}$" "$TMP_DIR/.claude/sdlc/${f}.md"
+  done
+}


### PR DESCRIPTION
## Summary

Closes #59 (Wave 8 P2 Gap-5) — `scripts/bootstrap-target.sh` создавал 6 артефактов с `type: placeholder`, которые `validate-artifact.sh` отклонял как невалидные. Любой immediate Edit после `/sdlc-init` блокировался hook'ом.

## Решение

Bootstrap теперь создаёт валидные минимально-полные артефакты с правильными `type:` полями:

| Файл | Старое | Новое | Дополнительные поля |
|---|---|---|---|
| `profile.md` | placeholder | `sdlc-profile` | project, created, updated |
| `plugin-config.md` | placeholder | `hooks-config` | project, version: 1, dates |
| `alphas.md` | placeholder | `alpha-snapshot` | source_of_truth, snapshot_role |
| `system-context.md` | placeholder | `attention-context` | current_focus |
| `roles.md` | placeholder | `role-journal` | active_roles: [] |
| `decisions.md` | placeholder | `decision-journal` | project, dates |

Type-значения соответствуют тем, что плагин использует в `dogfooding` `.claude/sdlc/` — гарантированно проходят `validate-artifact.sh`.

## Cleanup мёртвого кода

В процессе работы удалён pre-existing dead code:
- `write_if_absent` функция (никогда не вызывалась)
- `templates_root` переменная (никогда не использовалась)

Теперь shellcheck + shfmt clean (rc=0 без warnings).

## TDD-first (принцип 5)

1. `tests/unit/bootstrap-valid-frontmatter.bats` — 8 кейсов (red).
2. Заменил generic `for` loop на 6 typed heredocs.
3. Все 8/8 green.

```
ok 1 bootstrap creates profile.md with type sdlc-profile (not placeholder)
ok 2 bootstrap creates plugin-config.md with type hooks-config
ok 3 bootstrap creates alphas.md with type alpha-snapshot
ok 4 bootstrap creates system-context.md with type attention-context
ok 5 bootstrap creates roles.md with type role-journal
ok 6 bootstrap creates decisions.md with type decision-journal
ok 7 no artifact has type placeholder after bootstrap
ok 8 all 6 artifacts have project field matching target basename
```

## README updates

- Добавлен `bootstrap-valid-frontmatter.bats` в Tests&CI секцию.

## Plugin tools used (принцип 12 dogfooding)

- skill `/sdlc-phase development`
- `mcp__sdlc-state-rag__decisions_record` id=37
- TDD-first: red → fix → green
- Принципы: 1, 4a (no comments), 5, 12, 22

## Test plan

- [x] `bats tests/unit/bootstrap-valid-frontmatter.bats` — 8/8 green
- [x] `bats tests/unit/` — **129/129 green** (было 121, +8)
- [x] `shellcheck scripts/bootstrap-target.sh` — clean
- [x] `shfmt -i 2 -ci -d` — no diff
- [x] `bash scripts/check-readme-inventory.sh` — OK
- [ ] CI green
- [ ] After merge: будет включено в release v0.11.0

## AC coverage

- [x] AC-1: после `bootstrap-target.sh` — 6 артефактов проходят validate (нет placeholder)
- [x] AC-2: bats тесты обновлены (8 новых кейсов)

🤖 Generated with [Claude Code](https://claude.com/claude-code)