### PR TITLE
fix(mcp): bash-wrapper для launch-sdlc-state-rag без вложенного :- (v0.11.2 real fix)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-sdlc",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "AI-driven SDLC через призму системного мышления",
   "author": {
     "name": "Yuri Polosov",

--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -5,7 +5,7 @@ project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
 active_phase: deployment
-active_phase_set_at: 2026-05-11T08:21:18Z
+active_phase_set_at: 2026-05-11T08:35:00Z
 ---
 
 # SME-профиль проекта

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,8 +11,11 @@
     },
     "sdlc-state-rag": {
       "type": "stdio",
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh",
-      "args": [],
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec \"$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh\""
+      ],
       "env": {
         "SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 ## [Unreleased]
 
+## [0.11.2] — 2026-05-11
+
+### Fixed
+
+- **MCP `sdlc-state-rag` ✗ Failed to connect (продолжение v0.11.1)**. v0.11.1 fix не сработал: Claude Code **не expand'ит `${CLAUDE_PLUGIN_ROOT}`** в поле `command` `.mcp.json` (variable передаётся literally в exec, который не делает shell expansion).
+  - Возвращена bash-обёртка (как в v0.5.x), но БЕЗ вложенного `:-` fallback (этот баг из v0.5.x→v0.11.0):
+    - **До (v0.11.1)**: `"command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh", "args": []`
+    - **После (v0.11.2)**: `"command": "bash", "args": ["-c", "exec \"$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh\""]`
+  - Bash делает variable expansion на `$CLAUDE_PLUGIN_ROOT` (env var, который Claude Code инжектит в MCP child process).
+- `scripts/bootstrap-target.sh`: same fix для генерируемого `<target>/.mcp.json`.
+- `tests/unit/mcp-json-no-nested-fallback.bats` обновлён под bash wrapper (4 кейса).
+- `tests/integration/sdlc-state-rag-contract.bats` обновлён под bash wrapper (2 кейса).
+- Smoke-test: `CLAUDE_PLUGIN_ROOT=<cache>/0.11.1 bash -c 'exec "$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh"'` запускает MCP server (exit 124 от timeout = server alive on stdin).
+
+### Why
+
+v0.11.1 был incomplete fix. `${CLAUDE_PLUGIN_ROOT}` в `command` field остался **unsubstituted** в runtime (`claude mcp list` показывал literally `${CLAUDE_PLUGIN_ROOT}/scripts/...`). Bash wrapper нужен для shell expansion env var. Avoiding `:-` fallback избегает оригинального v0.11.0 баг.
+
 ## [0.11.1] — 2026-05-11
 
 ### Fixed

--- a/docs/release-notes/release-notes-v0.11.2.md
+++ b/docs/release-notes/release-notes-v0.11.2.md
@@ -1,0 +1,95 @@
+# Release v0.11.2 — реальный fix MCP sdlc-state-rag connect (bash wrapper, no `:-`)
+
+**Type:** patch (incomplete v0.11.1 → real fix).
+**Date:** 2026-05-11.
+
+## Контекст
+
+v0.11.1 пытался убрать bash-обёртку и использовать bare `${CLAUDE_PLUGIN_ROOT}` напрямую в `command`. **Не сработало** — Claude Code не делает variable substitution в `command` field:
+
+```bash
+$ claude mcp list | grep sdlc-state-rag
+sdlc-state-rag: ${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh  - ✗ Failed to connect
+```
+
+`${CLAUDE_PLUGIN_ROOT}` передаётся literally в exec, который не expand'ит variables.
+
+## Real fix
+
+Возвращаем bash-обёртку (как в v0.5.x), но **избегаем оригинальной ошибки** — никаких вложенных `:-` fallback'ов.
+
+```jsonc
+"sdlc-state-rag": {
+  "type": "stdio",
+  "command": "bash",
+  "args": [
+    "-c",
+    "exec \"$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh\""
+  ],
+  "env": {"SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"}
+}
+```
+
+Bash подставит `$CLAUDE_PLUGIN_ROOT` (env var, который Claude Code инжектит в MCP child process). Никаких fallback'ов — если переменная пуста, bash exec вылетит с явной ошибкой (видимо в логах), а не silently попадёт в неправильный путь.
+
+## Эволюция bag'а
+
+| Version | Pattern | Status |
+|---|---|---|
+| v0.5.x | `bash -c exec "$CLAUDE_PLUGIN_ROOT/scripts/..."` | ✓ Working (no nested `:-`) |
+| ...v0.10.0 | `bash -c exec "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/..."` | ✗ Bug: вложенный `:-` сворачивается |
+| v0.11.1 | `command: "${CLAUDE_PLUGIN_ROOT}/scripts/..."` | ✗ Claude Code не expand'ит в command |
+| **v0.11.2** | `bash -c exec "$CLAUDE_PLUGIN_ROOT/scripts/..."` (back to v0.5.x style) | ✓ Real fix |
+
+## Файлы изменены
+
+| File | Change |
+|---|---|
+| `.mcp.json` | bash wrapper с bare `$CLAUDE_PLUGIN_ROOT` |
+| `scripts/bootstrap-target.sh` | Same для генерируемого `<target>/.mcp.json` |
+| `.claude-plugin/plugin.json` | 0.11.1 → **0.11.2** |
+| `tests/unit/mcp-json-no-nested-fallback.bats` | Обновлён под bash wrapper (4 кейса) |
+| `tests/integration/sdlc-state-rag-contract.bats` | Обновлён (2 кейса) |
+
+## Verification
+
+Smoke-test:
+```bash
+CLAUDE_PLUGIN_ROOT=/home/ypolosov/.claude/plugins/cache/ypolosov/ai-driven-sdlc/0.11.2 \
+  bash -c 'exec "$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh"'
+# Server starts, blocks on stdin (timeout exit 124 = healthy)
+```
+
+`bats tests/unit/` — 159/159 green.
+`bats tests/integration/` — 47/47 green.
+
+After release + reconnect:
+```bash
+claude mcp list | grep sdlc-state-rag
+# Expected: bash -c exec "$CLAUDE_PLUGIN_ROOT/..." - ✓ Connected
+```
+
+## Установка
+
+```bash
+/plugin marketplace update ypolosov
+/plugin update ai-driven-sdlc
+```
+
+После update — restart Claude Code session (или `/mcp` reconnect для force-reload `.mcp.json`).
+
+## Что НЕ изменилось
+
+- `scripts/launch-sdlc-state-rag.sh` — не трогался.
+- `SDLC_STATE_RAG_DSN` — unset by default, pglite fallback.
+
+## Plugin tools used (принцип 12 dogfooding)
+
+- skill `/sdlc-phase deployment` методологически.
+- Smoke-test через bash CLI (не requires running MCP).
+- TDD: regression bats обновлены (red → green).
+- Принципы: 12, 22.
+
+## Impact
+
+P0 fix. v0.11.1 был incomplete — MCP всё ещё Failed to connect. Этот release реально подключает MCP для всех будущих sessions.

--- a/scripts/bootstrap-target.sh
+++ b/scripts/bootstrap-target.sh
@@ -239,7 +239,7 @@ new_entry = {
     "command": "bash",
     "args": [
         "-c",
-        'exec "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/launch-sdlc-state-rag.sh"',
+        'exec "$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh"',
     ],
     "env": {"SDLC_STATE_RAG_DSN": "${SDLC_STATE_RAG_DSN}"},
 }

--- a/tests/integration/sdlc-state-rag-contract.bats
+++ b/tests/integration/sdlc-state-rag-contract.bats
@@ -81,15 +81,16 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test ".mcp.json uses bare CLAUDE_PLUGIN_ROOT in command (v0.11.1 fix)" {
+@test ".mcp.json uses bash wrapper for sdlc-state-rag (v0.11.2 fix: Claude Code не expands в command field)" {
   command_value=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(d["mcpServers"]["sdlc-state-rag"]["command"])')
-  [[ "$command_value" == *'${CLAUDE_PLUGIN_ROOT}'* ]]
-  [[ "$command_value" != *':-'* ]]
+  [ "$command_value" = "bash" ]
 }
 
-@test ".mcp.json command references launch-sdlc-state-rag.sh (v0.11.1)" {
-  command_value=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(d["mcpServers"]["sdlc-state-rag"]["command"])')
-  [[ "$command_value" == *"launch-sdlc-state-rag.sh"* ]]
+@test ".mcp.json bash args reference launch-sdlc-state-rag.sh без вложенного fallback (v0.11.2)" {
+  args_str=$(python3 -c 'import json; d=json.load(open("'"$MCP_JSON"'")); print(" ".join(d["mcpServers"]["sdlc-state-rag"]["args"]))')
+  [[ "$args_str" == *"launch-sdlc-state-rag.sh"* ]]
+  [[ "$args_str" == *"CLAUDE_PLUGIN_ROOT"* ]]
+  [[ "$args_str" != *":-"* ]]
 }
 
 @test "launch-sdlc-state-rag.sh exists and is executable" {

--- a/tests/unit/mcp-json-no-nested-fallback.bats
+++ b/tests/unit/mcp-json-no-nested-fallback.bats
@@ -19,23 +19,27 @@ setup() {
   [ "$status" -ne 0 ]
 }
 
-@test ".mcp.json sdlc-state-rag command uses bare CLAUDE_PLUGIN_ROOT" {
+@test ".mcp.json sdlc-state-rag uses bash wrapper (Claude Code не expands \${CLAUDE_PLUGIN_ROOT} в command field, v0.11.2)" {
   run python3 -c "
 import json
 d = json.load(open('$MCP_JSON'))
-cmd = d['mcpServers']['sdlc-state-rag']['command']
-assert '\${CLAUDE_PLUGIN_ROOT}' in cmd, f'expected bare CLAUDE_PLUGIN_ROOT in command, got: {cmd}'
-assert ':-' not in cmd, f'nested fallback :- detected in command: {cmd}'
+entry = d['mcpServers']['sdlc-state-rag']
+assert entry['command'] == 'bash', f'expected command=bash, got: {entry[\"command\"]}'
+args = entry['args']
+assert args[0] == '-c', f'expected first arg=-c, got: {args[0]}'
+assert 'CLAUDE_PLUGIN_ROOT' in args[1], f'expected CLAUDE_PLUGIN_ROOT in bash script, got: {args[1]}'
+assert ':-' not in args[1], f'nested fallback :- detected: {args[1]}'
 "
   [ "$status" -eq 0 ]
 }
 
-@test ".mcp.json sdlc-state-rag command points to launch script" {
+@test ".mcp.json sdlc-state-rag args reference launch-sdlc-state-rag.sh" {
   run python3 -c "
 import json
 d = json.load(open('$MCP_JSON'))
-cmd = d['mcpServers']['sdlc-state-rag']['command']
-assert cmd.endswith('scripts/launch-sdlc-state-rag.sh'), f'expected launch script path, got: {cmd}'
+args = d['mcpServers']['sdlc-state-rag']['args']
+joined = ' '.join(args)
+assert 'launch-sdlc-state-rag.sh' in joined, f'expected launch script in args, got: {joined}'
 "
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

**v0.11.1 был incomplete fix.** MCP `sdlc-state-rag` всё ещё показывал `✗ Failed to connect`.

**Real fix:** возврат к bash-обёртке (как в v0.5.x), но БЕЗ вложенного `:-` fallback (исправленного оригинального бага из v0.11.0).

## Root cause v0.11.1 incompleteness

v0.11.1 пытался убрать bash-обёртку и использовать bare `${CLAUDE_PLUGIN_ROOT}` напрямую в `command`. **Claude Code не делает variable substitution в `command` field** — переменная передавалась literally:

```bash
$ claude mcp list | grep sdlc-state-rag
sdlc-state-rag: ${CLAUDE_PLUGIN_ROOT}/scripts/launch-sdlc-state-rag.sh  - ✗ Failed to connect
```

## Эволюция bug'а

| Version | Pattern | Status |
|---|---|---|
| v0.5.x | `bash -c exec "$CLAUDE_PLUGIN_ROOT/..."` | ✓ Working |
| ...v0.10.0 | `bash -c exec "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/..."` | ✗ `:-` сворачивается |
| v0.11.1 | `command: "${CLAUDE_PLUGIN_ROOT}/..."` | ✗ Claude не expand'ит в command |
| **v0.11.2** | `bash -c exec "$CLAUDE_PLUGIN_ROOT/..."` (v0.5.x style, no `:-`) | ✓ Real fix |

## Файлы изменены

| File | Change |
|---|---|
| `.mcp.json` | bash wrapper с bare `$CLAUDE_PLUGIN_ROOT` |
| `scripts/bootstrap-target.sh` | Same для генерируемого `<target>/.mcp.json` |
| `.claude-plugin/plugin.json` | 0.11.1 → **0.11.2** |
| `tests/unit/mcp-json-no-nested-fallback.bats` | Обновлён под bash wrapper (4 кейса) |
| `tests/integration/sdlc-state-rag-contract.bats` | Обновлён (2 кейса) |
| `CHANGELOG.md` + `release-notes-v0.11.2.md` | Detailed notes |

## Smoke-test (manual verification)

```bash
CLAUDE_PLUGIN_ROOT=/home/ypolosov/.claude/plugins/cache/ypolosov/ai-driven-sdlc/0.11.1 \
  bash -c 'exec "$CLAUDE_PLUGIN_ROOT/scripts/launch-sdlc-state-rag.sh"'
# Server starts, blocks on stdin (timeout exit 124 = healthy)
```

Подтверждает: bash expansion `$CLAUDE_PLUGIN_ROOT` работает корректно, script запускается.

## Test plan

- [x] `bats tests/unit/` — 159/159 green
- [x] `bats tests/integration/` — 47/47 green
- [x] Smoke-test bash wrapper — server starts
- [ ] CI green
- [ ] After merge: tag `v0.11.2` + GitHub Release
- [ ] After update: `claude mcp list | grep sdlc-state-rag` → ✓ Connected

## Plugin tools used (принцип 12 dogfooding)

- skill `/sdlc-phase deployment`
- TDD: regression bats updated.
- Принципы: 12, 22.

## Impact

**P0 fix.** v0.11.1 не починил MCP — этот release реально делает. Все MCP-based features (decisions, state advancement, audit, RAG) восстанавливаются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)