### PR TITLE
feat(wave-9): SDLC-first output style + SessionStart hook

### DIFF
--- a/.claude/sdlc/profile.md
+++ b/.claude/sdlc/profile.md
@@ -4,8 +4,8 @@ type: sdlc-profile
 project: ai-driven-sdlc-plugin
 created: 2026-04-19
 updated: 2026-05-05
-active_phase: deployment
-active_phase_set_at: 2026-05-11T08:55:00Z
+active_phase: development
+active_phase_set_at: 2026-05-11T12:00:00Z
 ---
 
 # SME-профиль проекта
@@ -58,3 +58,4 @@ active_phase_set_at: 2026-05-11T08:55:00Z
 - 2026-05-10 — фаза development активирована для Wave 8 PR-3 (#60 c4-diagram.meta.md).
 - 2026-05-10 — фаза development активирована для Wave 8 PR-4 (#59 bootstrap valid frontmatter).
 - 2026-05-11 — фаза deployment активирована для release v0.11.0 minor (Wave 8 closure).
+- 2026-05-11 — фаза development активирована для Wave 9 PR-1: SDLC-first output style + SessionStart hook.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 - `sdlc-tool-router` — маршрутизация запросов по категориям к MCP-серверам (Волна 4).
 - `sdlc-context-aggregator` — фасад консолидации контекста с провенансом (Волна 4, ADR-010).
 
-### Scripts (19)
+### Scripts (20)
 - `validate-artifact.sh` — frontmatter, секции, ≤15 слов, русский.
 - `enforce-tdd.sh` — мягкая блокировка записи кода без парного теста.
 - `enforce-format-lint.sh` — диспетчер форматера и линтера из `plugin-config.md`.
@@ -109,6 +109,7 @@
 - `enforce-sdlc-phase.sh` — PreToolUse hook принципа 22; блокирует git/gh/npm write-команды и Edit/Write без `active_phase` (Волна 5, v0.5.0).
 - `launch-sdlc-state-rag.sh` — launcher MCP-сервера sdlc-state-rag с fallback PATH→nvm→standard locations→npx (v0.5.2).
 - `check-adr-paths.sh` — валидирует `adr_paths` в `plugin-config.md` целевого (Волна 6, v0.6.0).
+- `inject-sdlc-context.sh` — SessionStart + PostToolUse hook; инжектит actual state (`active_phase`, focus, autonomy override) (Волна 9, v0.12.0).
 
 ### Meta-templates (26: 21 top + 5 external-systems)
 - `work-product.meta.md` — базовая схема рабочего продукта.
@@ -148,7 +149,10 @@
 - `catalogs/tool-categories.md` — 7 агностических категорий инструментов SDLC (Волна 4, ADR-013).
 
 ### Hooks (1 файл)
-- `hooks/hooks.json` — PreToolUse TDD (soft); PostToolUse порядок: validator → check-cross-refs → format/lint → no-comments → check-system-readmes → check-alpha-consistency.
+- `hooks/hooks.json` — SessionStart (inject-sdlc-context); PreToolUse enforce-sdlc-phase (Принцип 22 hard block) + TDD (soft); PostToolUse порядок: validator → check-cross-refs → format/lint → no-comments → check-system-readmes → check-alpha-consistency → inject-sdlc-context (refresh).
+
+### Output Styles (1)
+- `output-styles/sdlc-first.md` — обязательный анализ через плагин перед любым ответом. **Strong nudge, не hard block.** Активируется consensually через `/sdlc-init` (запись в `<target>/.claude/settings.local.json`). Деактивация: `/config` → Output style → Default. Реальный enforcement write-операций — PreToolUse `enforce-sdlc-phase.sh` (Принцип 22). (Волна 9, v0.12.0)
 
 ### Memom (Волна 2)
 - `memom.md` — журнал эволюции принципов плагина (принцип 15).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/inject-sdlc-context.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash|Write|Edit",
@@ -47,6 +57,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-alpha-consistency.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/inject-sdlc-context.sh"
           }
         ]
       }

--- a/output-styles/sdlc-first.md
+++ b/output-styles/sdlc-first.md
@@ -1,0 +1,68 @@
+---
+name: SDLC-first
+description: Анализ через ai-driven-sdlc-plugin перед любым ответом
+keep-coding-instructions: true
+force-for-plugin: false
+---
+
+# SDLC-first: обязательный анализ через ai-driven-sdlc-plugin
+
+Перед любым ответом или действием — обязательный шаг анализа через плагин ai-driven-sdlc.
+
+## 1. Применим ли плагин к запросу?
+
+- Разработка, проектирование, тестирование, deploy, ops, исследование артефактов SDLC — да.
+- Объяснение синтаксиса языка или общая теория без артефактов — нет; явно скажи об этом.
+
+## 2. Какая фаза SDLC соответствует запросу?
+
+Фазы: vision, requirements, architecture, development, testing, deployment, operations.
+Проверь `<target>/.claude/sdlc/profile.md` поле `active_phase` и `active_phase_set_at`.
+
+## 3. Какие инструменты плагина применимы
+
+### Команды (10)
+`/sdlc-init`, `/sdlc-continue`, `/sdlc-status`, `/sdlc-phase`, `/sdlc-focus`, `/sdlc-audit`, `/sdlc-autonomy`, `/sdlc-rag`, `/sdlc-tools`, `/sdlc-artifact` (internal).
+
+### Skills (13)
+`sdlc-vision`, `sdlc-requirements`, `sdlc-architecture`, `sdlc-development`, `sdlc-testing`, `sdlc-deployment`, `sdlc-operations`, `sdlc-bootstrap`, `sdlc-audit`, `sdlc-autonomy`, `sdlc-focus`, `sdlc-integrations`, `sdlc-method-engineering`.
+
+### Agents
+`sdlc-alpha-tracker`, `sdlc-consistency-auditor`, `sdlc-context-aggregator`, `sdlc-artifact-validator`, `sdlc-method-engineer`, `sdlc-state-reader`, `sdlc-tool-router`.
+
+### MCP tools
+`mcp__sdlc-state-rag__state_advance_alpha`, `state_advance_with_decision`, `decisions_record`, `audit_emit`, `rag_query_chunks`, `state_get_alpha`, `state_list_transitions`.
+
+### Hooks и скрипты
+`enforce-sdlc-phase` (Принцип 22), `enforce-tdd` (Принцип 5), `enforce-no-comments` (Принцип 4a), `enforce-format-lint` (Принцип 6), `validate-artifact`, `check-cross-refs`, `check-alpha-consistency`, `inject-sdlc-context`.
+
+### Принципы конституции (1–22 + 4a + 19a)
+Особенно: 1 (`AskUserQuestion` с альтернативами), 4 (русский, ≤15 слов), 4a (код без комментариев), 6 (deterministic > LLM), 12 (dogfooding), 13 (альфы только через tracker), 22 (active_phase для write).
+
+## 4. Обязательные правила в ответе
+
+- Явный блок `**Plugin tools used:** …` со ссылками на skill/command/agent/MCP/hook/принцип.
+- HITL — `AskUserQuestion` с 2–3 альтернативами ДО действия (Принцип 1).
+- Альфы — только через `sdlc-alpha-tracker`, не напрямую `alphas.md` (Принцип 13).
+- Артефакты SDLC — на русском, ≤15 слов на утверждение (Принцип 4).
+- Код без комментариев (Принцип 4a); shebang, license header, pragma — исключения.
+
+## 5. Если каркаса `.claude/sdlc/` нет
+
+Сначала предложи `/sdlc-init` через AskUserQuestion. Только после bootstrap — работа над фазами.
+
+## 6. Если active_phase не подходит запросу
+
+Предложи `/sdlc-phase <name>` для переключения. Не делай write-операции вне whitelist без активной фазы (Принцип 22 — реальный hard block через `enforce-sdlc-phase.sh`).
+
+## Anti-patterns
+
+- Молча `Edit` или `Write` в обход плагина без анализа.
+- HOOTL override `/sdlc-autonomy --task hootl --duration 24h` как continuous escape hatch (нарушение dogfooding).
+- Альфы напрямую в `alphas.md` минуя `sdlc-alpha-tracker`.
+- Ответ без блока `Plugin tools used:` на SDLC-задачу.
+- Игнорирование AskUserQuestion при HITL.
+
+## Скоп применимости
+
+Этот output style применяется когда плагин ai-driven-sdlc включён и активирован через `/sdlc-init` или `/config`. Деактивация — `/config` → Output style → Default.

--- a/scripts/bench-hooks.sh
+++ b/scripts/bench-hooks.sh
@@ -15,6 +15,7 @@ scripts["check-alpha-consistency"]="$root/scripts/check-alpha-consistency.sh"
 scripts["enforce-no-comments"]="$root/scripts/enforce-no-comments.sh"
 scripts["enforce-format-lint"]="$root/scripts/enforce-format-lint.sh"
 scripts["enforce-sdlc-phase"]="$root/scripts/enforce-sdlc-phase.sh"
+scripts["inject-sdlc-context"]="$root/scripts/inject-sdlc-context.sh"
 
 sample_artifact="$root/.claude/sdlc/phases/testing/testing.md"
 sample_alphas="$root/.claude/sdlc/alphas.md"
@@ -69,6 +70,10 @@ for name in "${!scripts[@]}"; do
       ;;
     enforce-sdlc-phase)
       payload=$(printf '{"tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"%s"}' "$root")
+      cmd="printf '%s' '$payload' | bash '$path'"
+      ;;
+    inject-sdlc-context)
+      payload=$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$root")
       cmd="printf '%s' '$payload' | bash '$path'"
       ;;
     *)

--- a/scripts/check-readme-inventory.sh
+++ b/scripts/check-readme-inventory.sh
@@ -34,6 +34,7 @@ commands = {f[:-3] for f in list_files("commands", ".md")}
 agents = {f[:-3] for f in list_files("agents", ".md")}
 scripts = list_files("scripts", ".sh")
 meta = list_files("meta-templates", ".md")
+output_styles = list_files("output-styles", ".md")
 
 with open(readme_path, encoding="utf-8") as f:
     text = f.read()
@@ -47,6 +48,7 @@ commands_readme = set(re.findall(r"/(sdlc-[a-z-]+)", find_section("Commands")))
 agents_readme = set(re.findall(r"`(sdlc-[a-z-]+)`", find_section("Agents")))
 scripts_readme = set(re.findall(r"`([a-z][a-z0-9-]*\.sh)`", find_section("Scripts")))
 meta_readme = set(re.findall(r"`([a-z][a-z0-9.\-]*\.meta\.md)`", find_section("Meta-templates")))
+output_styles_readme = set(re.findall(r"`output-styles/([a-z][a-z0-9-]*\.md)`", find_section("Output Styles")))
 
 errors = 0
 
@@ -66,6 +68,8 @@ check("commands", commands, commands_readme)
 check("agents", agents, agents_readme)
 check("scripts", scripts, scripts_readme)
 check("meta-templates", meta, meta_readme)
+if output_styles:
+    check("output-styles", output_styles, output_styles_readme)
 
 if errors:
     print(f"check-readme-inventory: {errors} расхождений. Обновите README.md.", file=sys.stderr)

--- a/scripts/inject-sdlc-context.sh
+++ b/scripts/inject-sdlc-context.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload="$(cat)"
+
+result="$(
+  SDLC_PAYLOAD="$payload" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+payload = json.loads(os.environ.get("SDLC_PAYLOAD", "{}"))
+event = payload.get("hook_event_name", "")
+cwd = payload.get("cwd", "")
+tool_name = payload.get("tool_name", "")
+tool_input = payload.get("tool_input") or {}
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if event == "PostToolUse":
+  trigger_files = (".claude/sdlc/profile.md", ".claude/sdlc/system-context.md")
+  if not any(file_path.endswith(t) for t in trigger_files):
+    sys.exit(0)
+
+if not cwd:
+  sys.exit(0)
+
+sdlc_dir = os.path.join(cwd, ".claude/sdlc")
+parts = ["[SDLC state]"]
+
+if not os.path.isdir(sdlc_dir):
+  parts.append("каркас .claude/sdlc/ отсутствует — предложи /sdlc-init")
+else:
+  profile_path = os.path.join(sdlc_dir, "profile.md")
+  if os.path.isfile(profile_path):
+    with open(profile_path, encoding="utf-8") as f:
+      txt = f.read()
+    m = re.search(r"^active_phase:\s*(\S+)", txt, flags=re.MULTILINE)
+    parts.append(f"active_phase={m.group(1)}" if m else "active_phase=—")
+    m = re.search(r"^active_phase_set_at:\s*(\S+)", txt, flags=re.MULTILINE)
+    if m:
+      parts.append(f"set_at={m.group(1)}")
+
+  ctx_path = os.path.join(sdlc_dir, "system-context.md")
+  if os.path.isfile(ctx_path):
+    with open(ctx_path, encoding="utf-8") as f:
+      txt = f.read()
+    m = re.search(r"^current_system:\s*(.+)$", txt, flags=re.MULTILINE)
+    if m:
+      parts.append(f"focus={m.group(1).strip()}")
+
+  session_path = os.path.join(sdlc_dir, "autonomy.session.md")
+  if os.path.isfile(session_path):
+    parts.append("autonomy_override=active")
+
+ctx = "; ".join(parts)
+out = {
+  "hookSpecificOutput": {
+    "hookEventName": event or "SessionStart",
+    "additionalContext": ctx,
+  }
+}
+print(json.dumps(out, ensure_ascii=False))
+PY
+)"
+
+if [ -n "$result" ]; then
+  echo "$result"
+fi
+exit 0

--- a/skills/sdlc-bootstrap/SKILL.md
+++ b/skills/sdlc-bootstrap/SKILL.md
@@ -45,6 +45,7 @@ meta_templates: [profile.meta.md, plugin-config.meta.md, alpha-state.meta.md, sy
 3. Какую роль вы играете сейчас? (выбор из `catalogs/roles.md`)
 4. Какую систему считаете целевой на старте? (обычно корневая система репозитория)
 5. Где хранить состояние работ? (state-артефакт: файл / каталог / GitHub Issues через MCP)
+6. Активировать output style `SDLC-first` как default outputStyle? (consensual, Принцип 1)
 
 Вопросы про конкретные инструменты не задаются здесь — только в skills фаз.
 
@@ -66,6 +67,8 @@ meta_templates: [profile.meta.md, plugin-config.meta.md, alpha-state.meta.md, sy
 8. Создать `decisions.md` по `decisions.meta.md` (пустой журнал).
 9. Создать `.env.example` и дополнить `.gitignore` строкой `.env` (по `credentials.meta.md`).
 10. Зафиксировать первый choice в `decisions.md`: выбранные уровень проекта и state-артефакт.
+11. Если пользователь выбрал активацию SDLC-first: записать `outputStyle: "SDLC-first"` в `<target>/.claude/settings.local.json` (merge с существующим).
+12. Зафиксировать выбор output style в `decisions.md` (вместе с альтернативой Default).
 
 Команда плагина: `/sdlc-init`. Реализация в `scripts/bootstrap-target.sh`.
 


### PR DESCRIPTION
## Summary

Решение задачи: harness-enforced проактивное применение плагина `ai-driven-sdlc-plugin` на каждом промте. Memory оказалась мягким механизмом — я её игнорировал. Нужен harness-исполняемый механизм.

**4-уровневая защита** (план v3 после критического аудита):

| Уровень | Механизм | Когда |
|---|---|---|
| 1 (главный) | Output Style `sdlc-first` (модифицирует system prompt) | Когда активирован через `/sdlc-init` |
| 2 | SessionStart + PostToolUse refresh hooks (`inject-sdlc-context.sh`) | На старте сессии + при изменении `profile.md`/`system-context.md` |
| 3 (hard block) | PreToolUse `enforce-sdlc-phase.sh` (был) | На каждый Write/Edit/Bash вне whitelist |
| 4 (backup) | Memory `feedback_default_use_ai_driven_sdlc_plugin.md` | Когда плагин выключен |

### Изменения

**Создано:**
- `output-styles/sdlc-first.md` — `force-for-plugin: false`, `keep-coding-instructions: true`. Активация через `/sdlc-init` (`AskUserQuestion`, Принцип 1).
- `scripts/inject-sdlc-context.sh` — bash+python3, skip-logic для PostToolUse, JSON output с `additionalContext`.

**Изменено:**
- `hooks/hooks.json` — добавлен `SessionStart` event + `inject-sdlc-context.sh` в `PostToolUse` (теперь 7 хуков в PostToolUse).
- `skills/sdlc-bootstrap/SKILL.md` — вопрос #6 про активацию outputStyle + шаги 11-12 (запись в `settings.local.json` и `decisions.md`).
- `README.md` — Scripts (20), новый раздел Output Styles с явным disclaimer «strong nudge, не hard block».
- `scripts/bench-hooks.sh` — бенчмарк `inject-sdlc-context.sh` (40 ms vs 200 ms threshold).
- `scripts/check-readme-inventory.sh` — учёт `output-styles/` директории.
- `.claude/sdlc/profile.md` — `active_phase: development` для Wave 9 PR-1.

### Ключевые архитектурные решения

- **`force-for-plugin: false`** (не `true`) — consensual активация, не подавляет outputStyle других пользователей плагина (Принцип 1).
- **SessionStart + PostToolUse refresh** (не UserPromptSubmit на каждый промт) — экономит токены; state не меняется на каждый промт, только на mutations.
- **Не вводим Принцип 23 в `CLAUDE.md`** — сначала проверяем эффективность hook'а; формализация — отдельный PR с записью в `memom.md` (Принцип 15).

## Test plan

- [x] Frontmatter `output-styles/sdlc-first.md` корректный (`force-for-plugin: false`, `keep-coding-instructions: true`).
- [x] `hooks/hooks.json` валиден; 3 events: SessionStart (1 hook), PreToolUse, PostToolUse (7 hooks).
- [x] `inject-sdlc-context.sh` SessionStart: инжектит `[SDLC state]; active_phase=development; set_at=…`.
- [x] `inject-sdlc-context.sh` PostToolUse on `profile.md`: инжектит state (refresh).
- [x] `inject-sdlc-context.sh` PostToolUse on не-trigger file: silent skip (exit 0, no output).
- [x] `inject-sdlc-context.sh` cwd без `.claude/sdlc/`: инжектит реминдер про `/sdlc-init`.
- [x] `check-readme-inventory.sh`: OK (учёт output-styles).
- [x] `bench-hooks.sh`: `inject-sdlc-context` 40 ms < 200 ms (Принцип 6).
- [ ] **Real session test** (после merge + рестарта): SessionStart system-reminder с инструкциями SDLC-first; ответ на dev-задачу содержит блок `Plugin tools used:`.
- [ ] **AskUserQuestion в `/sdlc-init`**: при активации outputStyle — запись в `<target>/.claude/settings.local.json`.

## Plugin tools used

- **Принципы**: 1 (AskUserQuestion с альтернативами), 4 (русский, ≤15 слов), 4a (код без комментариев), 6 (deterministic > LLM), 12 (dogfooding), 14 (path convention), 16 (README как живой артефакт), 22 (active_phase для write).
- **Skill**: `sdlc-bootstrap` (расширен вопросом #6 и шагами 11-12).
- **Hook script (new)**: `inject-sdlc-context.sh` — SessionStart + PostToolUse.
- **Scripts (updated)**: `bench-hooks.sh`, `check-readme-inventory.sh`.
- **Hooks (updated)**: `hooks/hooks.json` — SessionStart event + PostToolUse refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)